### PR TITLE
Adds script to start/stop dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,31 @@ This project contains the OpenAPI v3 specification for [Conjur OSS](https://www.
 
 This project requires Docker and access to DockerHub
 
-## Running
+## Environment Setup
+
+Setup the development environment using the `start` script. The script starts a Swagger UI 
+container, used to the edit the OpenAPI spec, and stands up a new instance of Conjur to test the 
+spec against.
+
+```shell
+$ ./bin/start
+```
+
+To use the OpenAPI spec against a pre-existing Conjur server, start the Swagger UI editor with 
+the `start_editor` script.
 
 ```shell
 $ ./bin/start_editor
 ```
 
-A browser window will be opened to the container running Swagger UI.
-
+In each case, a browser window will be opened to the container running Swagger UI.
 Import the [`conjur-openapi.yml`](conjur-openapi.yml) into the UI to view/edit.
+
+The environment can be stopped and removed using the `stop` script.
+
+```shell
+$ ./bin/stop
+```
 
 ## Editing
 

--- a/bin/integration_tests
+++ b/bin/integration_tests
@@ -10,19 +10,7 @@ if [ "$1" == "-d" ]; then
   shift
 fi
 
-trap 'echo "ERROR: Test script encountered an error!"; docker-compose logs; cleanup' ERR
-trap 'cleanup' EXIT
-cleanup
-
-echo "Generating Client"
-./bin/generate_client
-
-echo "Building API container..."
-docker-compose build
-
-echo "Starting Conjur..."
-docker-compose up -d conjur
-docker-compose exec -T conjur conjurctl wait
+bin/start_conjur
 
 echo "Configuring Conjur..."
 admin_api_key=$(docker-compose exec -T conjur conjurctl role retrieve-key dev:user:admin | tr -d '\r')

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+# Start Conjur docker-compose environment
+bin/start_conjur
+
+# Start Swagger UI
+bin/start_editor

--- a/bin/start_conjur
+++ b/bin/start_conjur
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+cleanup() {
+  echo "Cleaning up..."
+  docker-compose rm --stop --force -v
+}
+
+if [ "$1" == "-d" ]; then
+  DEBUG="true"
+  shift
+fi
+
+trap 'echo "ERROR: Test script encountered an error!"; docker-compose logs; cleanup' ERR
+cleanup
+
+echo "Building services..."
+docker-compose build
+
+# Start Conjur server
+echo "Starting Conjur..."
+docker-compose up -d conjur conjur-https
+docker-compose exec -T conjur conjurctl wait

--- a/bin/stop
+++ b/bin/stop
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# deconstruct docker-compose env
+echo "Stop and remove docker-compose environment"
+docker-compose down -v
+
+# stop and remove swagger container
+echo "Stop and remove Swagger container"
+docker stop swagger-editor || true
+docker rm swagger-editor || true


### PR DESCRIPTION
This PR adds scripts to easily setup and tear down a development environment for the OpenAPI spec. The script spins up a new Conjur server and the Swagger UI. Adds documentation to the README concerning starting and stopping the environment.

Resolves #7 