### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+* @cyberark/community-and-integrations-team @conjurinc/community-and-integrations-team @conjurdemos/community-and-integrations-team
+
+# Changes to .trivyignore require Security Architect approval
+.trivyignore @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+
+# Changes to SECURITY.md require Security Architect approval
+SECURITY.md @cyberark/security-architects @conjurinc/security-architects @conjurdemos/security-architects
+
+# Changes to .codeclimate.yml require Quality Architect approval
+.codeclimate.yml @cyberark/quality-architects @conjurinc/quality-architects @conjurdemos/quality-architects


### PR DESCRIPTION
Code owners are automatically requested for review on PRs.
Necessary for repo publicity.

Partially addresses #2 