### PR TITLE
Jenkinsfile formatting fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
                 sh './bin/integration_tests'
             }
         }
+    }
 
     post {
         always {


### PR DESCRIPTION
Jenkinsfile was missing a closing bracket.
Pipeline now runs successfully.