### PR TITLE
Added linting stage to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,11 @@ pipeline {
                 sh './bin/integration_tests'
             }
         }
+        stage('Linting') {
+            steps {
+                sh './bin/lint_tests'
+            }
+        }
     }
 
     post {


### PR DESCRIPTION
Allows for viewing of all automated processes on Jenkins not just integration tests

### What does this PR do?
Added a linting stage to the Jenkins CI pipeline

### What ticket does this PR close?
Partially Addresses #20 The pipeline still needs to be split into cleaner stages with better feedback. Just wanted to get linting included in Jenkins CI, will fully address this issue in a second PR.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
