### PR TITLE
Updated return schema for openapi definitions

### DIFF
--- a/conjur-openapi.yml
+++ b/conjur-openapi.yml
@@ -875,7 +875,9 @@ paths:
         201:
           description: "The response body contains the requested role(s)/member(s)"
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: object
         401:
           $ref: '#/components/responses/UnauthorizedError'
         403:
@@ -949,7 +951,9 @@ paths:
         200:
           description: "The response body contains the list of matching resources"
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: object
         401:
           $ref: '#/components/responses/UnauthorizedError'
 
@@ -1014,7 +1018,9 @@ paths:
         200:
           description: "The response body contains the list of role memberships or permitted roles"
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: object
         204:
           $ref: '#/components/responses/PermissionCheckSuccess'
         401:
@@ -1058,7 +1064,9 @@ paths:
         200:
           description: "Zero or more tokens were created and delivered in the response body"
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: object
         403:
           $ref: '#/components/responses/InadequatePrivileges'
         404:
@@ -1124,7 +1132,9 @@ paths:
         201:
           description: "The response body contains the newly-created host"
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: object
         401:
           $ref: '#/components/responses/UnauthorizedError'
         422:


### PR DESCRIPTION
Fixes issue with python client not returning any value from http requests.

### What does this PR do?
Changed the return schema for some HTTP functions from `application/json: {}` to
```json
application/json:
    schema:
        type: object
```

This is a temporary fix. Eventually these functions will need actual return schemas specified. However currently there are no return object schemas specified in the standard so this will unblock the testing PR #39. A new issue has been opened to address the return schema issue #43. 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
