### PR TITLE
Added yaml linting for openapi spec file

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,30 +1,47 @@
 name: Test Code Quality
 
 on:
-    push:
-        branches: [ main ]
-    pull_request:
-        branches: [ main ]
-        types: [opened, synchronize, reopened, edited]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
-    pylint:
-        runs-on: ubuntu-latest
-        name: Python Test Linting
-        steps:
-            - name: Checkout the repo
-              uses: actions/checkout@v2
+  pylint:
+    runs-on: ubuntu-latest
+    name: Python Test Linting
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
 
-            - name: Setup python
-              uses: actions/setup-python@v2
-              with:
-                python-version: '3.x'
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
 
-            - name: Generate python client
-              run: ./bin/generate_client
+      - name: Generate python client
+        run: ./bin/generate_client
 
-            - name: Install the client
-              run: python -m pip install out/python pylint
+      - name: Install the client
+        run: python -m pip install out/python pylint
 
-            - name: Run Pylint
-              run: pylint test/python --rcfile=test/config/.pylintrc
+      - name: Run Pylint
+        run: pylint test/python --rcfile=test/config/.pylintrc
+
+  spectral:
+    runs-on: ubuntu-latest
+    name: Spec File Linting
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+
+      - name: Install Spectral
+        run: npm install -g @stoplight/spectral
+
+      - name: Run Spectral Linting
+        run: spectral lint -v --fail-severity=warn -s oas3-api-servers conjur-openapi.yml
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
         stage('Linting') {
             steps {
                 sh './bin/lint_tests'
+                sh './bin/lint_spec'
             }
         }
     }

--- a/bin/lint_spec
+++ b/bin/lint_spec
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+
+docker run --rm \
+    -v ${PWD}/conjur-openapi.yml:/code/conjur-openapi.yml \
+    node:latest \
+    /bin/bash -c "npm i -g @stoplight/spectral && spectral lint -v --fail-severity=warn -s oas3-api-servers /code/conjur-openapi.yml"

--- a/bin/lint_tests
+++ b/bin/lint_tests
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exit_code=0
+
 echo "Linting Python integration tests:"
 docker run --rm \
     -v ${PWD}/test/python:/code/test \
@@ -11,5 +13,18 @@ docker run --rm \
 if [ $? -ne 0 ]
 then
     echo "Error: Your Pylint score must be 10.0 to pass Python linting test"
-    exit 1
+    exit_code=$((exit_code | 1))
 fi
+
+docker run --rm \
+    -v ${PWD}/conjur-openapi.yml:/code/conjur-openapi.yml \
+    node:latest \
+    /bin/bash -c "npm i -g @stoplight/spectral && spectral lint /code/conjur-openapi.yml"
+
+if [ $? -ne 0 ]
+then
+    echo "Error: Your Spectral linting score must be 10.0 to pass Yaml linting test"
+    exit_code=$((exit_code | 1))
+fi
+
+exit $exit_code

--- a/bin/lint_tests
+++ b/bin/lint_tests
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-exit_code=0
-
 echo "Linting Python integration tests:"
 docker run --rm \
     -v ${PWD}/test/python:/code/test \
@@ -13,18 +11,5 @@ docker run --rm \
 if [ $? -ne 0 ]
 then
     echo "Error: Your Pylint score must be 10.0 to pass Python linting test"
-    exit_code=$((exit_code | 1))
+    exit 1
 fi
-
-docker run --rm \
-    -v ${PWD}/conjur-openapi.yml:/code/conjur-openapi.yml \
-    node:latest \
-    /bin/bash -c "npm i -g @stoplight/spectral && spectral lint /code/conjur-openapi.yml"
-
-if [ $? -ne 0 ]
-then
-    echo "Error: Your Spectral linting score must be 10.0 to pass Yaml linting test"
-    exit_code=$((exit_code | 1))
-fi
-
-exit $exit_code

--- a/conjur-openapi.yml
+++ b/conjur-openapi.yml
@@ -23,19 +23,11 @@ tags:
   description: "Host factories"
 - name: "public keys"
   description: "SSH keys"
+- name: "resources"
+  description: "Resources"
   
 components:
   schemas:
-    AccessToken:
-      type: object
-      properties:
-        protected:
-          type: string
-        payload:
-          type: string
-        signature:
-          type: string
-
     AccountName:
       type: string
       minLength: 1
@@ -43,7 +35,7 @@ components:
 
     CheckPrivilege:
       type: boolean
-      example: "true"
+      example: true
       description: "Checks whether a role has a privilege on a resource."
 
     CreateHostRequest:
@@ -57,7 +49,7 @@ components:
         annotations:
           description: "Annotations to apply to the new host"
           type: object
-          example: '{"puppet": "true", "description": "new db host"}'
+          example: {"puppet": "true", "description": "new db host"}
 
       required:
         - id
@@ -87,7 +79,7 @@ components:
         count:
           description: "Number of host tokens to create"
           type: integer
-          example: "2"
+          example: 2
 
         cidr:
           # TODO: Find out if we accept string or an array
@@ -95,7 +87,7 @@ components:
           type: array
           items:
             type: string
-          example: "127.0.0.1/32"
+          example: ["127.0.0.1/32"]
 
       required:
         - expiration
@@ -123,7 +115,7 @@ components:
 
     PermittedRoles:
       type: boolean
-      example: "true"
+      example: true
 
     Policy:
       type: string
@@ -256,7 +248,7 @@ components:
         application/json:
           schema:
             type: object
-            example: |
+            example:
               {
                 "created_roles": {
                   "myorg:host:database/db-host": {
@@ -294,7 +286,7 @@ components:
         application/json:
           schema:
             type: object
-            example: |
+            example:
               {
                  "myorg:variable:secret1": "secret1Value",
                  "myorg:variable:secret2": "secret2Value"
@@ -343,9 +335,9 @@ paths:
         schema:
           $ref: '#/components/schemas/AccountName'
       responses:
-        200:
+        "200":
           $ref: '#/components/responses/ApiKey'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
       security:
         - basicAuth: []
@@ -391,9 +383,9 @@ paths:
             schema:
               $ref: '#/components/schemas/ApiKey'
       responses:
-        200:
+        "200":
           $ref: '#/components/responses/AccessTokenGeneric'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
       security:
         - conjurAuth: []
@@ -429,13 +421,13 @@ paths:
               minLength: 1
 
       responses:
-        204:
+        "204":
           description: "The password has been changed"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           description: "The user was not found"
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
       security:
         - basicAuth: []
@@ -471,9 +463,9 @@ paths:
           $ref: '#/components/schemas/Role'
 
       responses:
-        200:
+        "200":
           $ref: '#/components/responses/ApiKey'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
       security:
         - basicAuth: []
@@ -520,13 +512,13 @@ paths:
               format: binary
 
       responses:
-        201:
+        "201":
           description: "The secret value was added successfully"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
 
       security:
@@ -570,15 +562,15 @@ paths:
           $ref: '#/components/schemas/ResourceVersion'
 
       responses:
-        200:
+        "200":
           $ref: '#/components/responses/SecretValue'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        404:
+        "404":
           $ref: '#/components/responses/ResourceNotFound'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
 
       security:
@@ -600,15 +592,15 @@ paths:
           $ref: '#/components/schemas/ResourceIDs'
 
       responses:
-        200:
+        "200":
           $ref: '#/components/responses/SecretBatchValue'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        404:
+        "404":
           $ref: '#/components/responses/ResourcesNotFound'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
 
       security:
@@ -659,17 +651,17 @@ paths:
               $ref: '#/components/schemas/Policy'
 
       responses:
-        201:
+        "201":
           $ref: '#/components/responses/LoadedPolicy'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        404:
+        "404":
           $ref: '#/components/responses/ResourceNotFound'
-        409:
+        "409":
           $ref: '#/components/responses/Busy'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
 
       security:
@@ -718,17 +710,17 @@ paths:
               $ref: '#/components/schemas/Policy'
 
       responses:
-        201:
+        "201":
           $ref: '#/components/responses/LoadedPolicy'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        404:
+        "404":
           $ref: '#/components/responses/ResourceNotFound'
-        409:
+        "409":
           $ref: '#/components/responses/Busy'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
 
       security:
@@ -778,17 +770,17 @@ paths:
               $ref: '#/components/schemas/Policy'
 
       responses:
-        201:
+        "201":
           $ref: '#/components/responses/LoadedPolicy'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        404:
+        "404":
           $ref: '#/components/responses/ResourceNotFound'
-        409:
+        "409":
           $ref: '#/components/responses/Busy'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
 
       security:
@@ -872,17 +864,17 @@ paths:
           $ref: '#/components/schemas/Count'
 
       responses:
-        201:
+        "201":
           description: "The response body contains the requested role(s)/member(s)"
           content:
             application/json:
               schema:
                 type: object
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        404:
+        "404":
           $ref: '#/components/responses/ResourceNotFound'
 
       security:
@@ -948,13 +940,13 @@ paths:
           $ref: '#/components/schemas/Count'
 
       responses:
-        200:
+        "200":
           description: "The response body contains the list of matching resources"
           content:
             application/json:
               schema:
                 type: object
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
 
       security:
@@ -1015,21 +1007,21 @@ paths:
           $ref: '#/components/schemas/Role'
 
       responses:
-        200:
+        "200":
           description: "The response body contains the list of role memberships or permitted roles"
           content:
             application/json:
               schema:
                 type: object
-        204:
+        "204":
           $ref: '#/components/responses/PermissionCheckSuccess'
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        404:
+        "404":
           $ref: '#/components/responses/ResourceNotFound'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
       security:
         - conjurAuth: []
@@ -1061,17 +1053,17 @@ paths:
               $ref: '#/components/schemas/HostFactoryTokenRequest'
 
       responses:
-        200:
+        "200":
           description: "Zero or more tokens were created and delivered in the response body"
           content:
             application/json:
               schema:
                 type: object
-        403:
+        "403":
           $ref: '#/components/responses/InadequatePrivileges'
-        404:
+        "404":
           $ref: '#/components/responses/ResourceNotFound'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
 
       security:
@@ -1098,11 +1090,11 @@ paths:
         schema:
           $ref: '#/components/schemas/HostFactoryToken'
       responses:
-        204:
+        "204":
           description: "Token was successfully revoked"
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        404:
+        "404":
           $ref: '#/components/responses/ResourceNotFound'
 
       security:
@@ -1129,15 +1121,15 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateHostRequest'
       responses:
-        201:
+        "201":
           description: "The response body contains the newly-created host"
           content:
             application/json:
               schema:
                 type: object
-        401:
+        "401":
           $ref: '#/components/responses/UnauthorizedError'
-        422:
+        "422":
           $ref: '#/components/responses/MissingOrBadRequestParameters'
       security:
         - conjurAuth: []
@@ -1177,7 +1169,7 @@ paths:
           $ref: '#/components/schemas/ResourceID'
 
       responses:
-        200:
+        "200":
           $ref: '#/components/responses/PublicKeys'
 
 # TODO: Inject client cert

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -4,7 +4,6 @@ import pathlib
 import unittest
 
 import openapi_client
-import openapi_client.models.access_token
 
 CERT_DIR = pathlib.Path('config/https')
 SSL_CERT_FILE = 'ca.crt'


### PR DESCRIPTION
Will help keep the yaml cleaner and eliminate any accidental errors from bad formatting in the file. A YAML linting step will have to be added to both Jenkins and Github Actions after the file meets the linting standards.

### What does this PR do?
Added a check in the lint_tests file which will lint the OpenAPI YAML specification

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
