### PR TITLE
Update scripts to only build required docker-compose services

### DIFF
--- a/bin/integration_tests
+++ b/bin/integration_tests
@@ -23,7 +23,8 @@ cat <<ENV > .env
 CONJUR_AUTHN_API_KEY=$admin_api_key
 ENV
 
-echo "Starting test env..."
+echo "Building and starting test env..."
+docker-compose build test-python
 docker-compose up -d test-python
 
 rm -rf $CURRENT_DIR/output/*

--- a/bin/start_conjur
+++ b/bin/start_conjur
@@ -14,7 +14,7 @@ trap 'echo "ERROR: Test script encountered an error!"; docker-compose logs; clea
 cleanup
 
 echo "Building services..."
-docker-compose build
+docker-compose build pg conjur conjur-https
 
 # Start Conjur server
 echo "Starting Conjur..."


### PR DESCRIPTION
### What does this PR do?
In another set of commits, I containerize a client use case example by adding
another service to the docker-compose environment. These changes ensure that each
process only builds the services that it requires, making script output more focused.

### What ticket does this PR close?
No related issue ticket.
Prerequisite to merge PR #42 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
