### PR TITLE
Added check for rebasing into main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,19 @@
 name: Integration Tests
 
 on:
-    push:
-        branches: [ main ]
-    pull_request:
-        branches: [ main ]
-        types: [opened, synchronize, reopened, edited]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
-    python:
-        runs-on: ubuntu-latest
-        name: Python Integration Tests
-        steps:
-            - name: checkout the repo
-              uses: actions/checkout@v2
+  python:
+    runs-on: ubuntu-latest
+    name: Python Integration Tests
+    steps:
+      - name: checkout the repo
+        uses: actions/checkout@v2
 
-            - name: run integration test script
-              run: ./bin/integration_tests
+      - name: run integration test script
+        run: ./bin/integration_tests

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,21 @@
+name: Rebase Check
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  force_rebase:
+    runs-on: ubuntu-latest
+    name: Enforce Rebasing
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check for rebase
+        uses: telday/enforce-rebase@v2
+        with:
+          default-branch: main


### PR DESCRIPTION
Makes sure that all PR's have been rebased on main before being pulled into the main branch

### What does this PR do?
Added a GitHub action for checking to make sure that a PR branch has been rebased on master. This
is similar to the action used on the main [Conjur repo](https://github.com/cyberark/conjur/blob/master/.github/workflows/main.yml)

Resolves: #55 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
