### PR TITLE
Add API Contract Testing

### DIFF
--- a/.github/workflows/api_contract.yml
+++ b/.github/workflows/api_contract.yml
@@ -1,0 +1,19 @@
+name: API Contract Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  contract_test:
+    runs-on: ubuntu-latest
+    name: API Contract Test
+    steps:
+      - name: checkout the repo
+        uses: actions/checkout@v2
+
+      - name: run api contract test script
+        run: ./bin/api_test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,13 @@ $ ./bin/stop
     * `File` > `Save as YAML`
 5. Overwrite [`conjur-openapi.yml`](conjur-openapi.yml) with the downloaded YAML file
 
+After editing the OpenAPI spec, it's important to test your changes using `bin/api_test`.
+
 ### Utility Script Reference
+
+`bin/api_test [-e <endpoint>]`
+* Runs containerized contract testing on all endpoints specified in [`conjur-openapi.yml`](conjur-openapi.yml)
+* Specifying an endpoint with the `-e|--endpoint` flag runs contract tests on that endpoint alone.
 
 `bin/generate_client <language>`
 * Generates a client library for the desired `<language>`.  

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,12 @@ pipeline {
                 sh './bin/lint_spec'
             }
         }
+        
+        stage('API Contract Test') {
+            steps {
+                sh './bin/api_test'
+            }
+        }
     }
 
     post {

--- a/bin/api_test
+++ b/bin/api_test
@@ -60,9 +60,12 @@ docker-compose run --rm --no-deps \
     bash -c \
     "schemathesis run \
     --show-errors-tracebacks \
-    --hypothesis-deadline None \
     --request-tls-verify /config/ca.crt \
-    -c all ${endpoint_flag}\
+    --hypothesis-deadline None ${endpoint_flag}\
+    --checks status_code_conformance \
+    --checks content_type_conformance \
+    --checks response_headers_conformance \
+    --checks response_schema_conformance \
     -H \"Authorization: Basic \"$ENCODED_LOGIN\"\" \
     -H \"Authentication: Token token=\"$CONJUR_ADMIN_TOKEN\"\" \
     --base-url https://conjur-https conjur-openapi.yml"

--- a/bin/api_test
+++ b/bin/api_test
@@ -1,0 +1,68 @@
+#!/bin/bash
+function announce() {
+  echo "+++++++++++++++"
+  echo "$@"
+  echo "+++++++++++++++"
+}
+
+endpoint_flag=""
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      announce "API Test Script"
+      echo "Uses Schemathesis to generate test cases for"
+      echo "API endpoints, which test the conformance between"
+      echo "Conjur OSS and the OpenAPI specification."
+      echo
+      echo "Usage"
+      echo "./bin/api_test [options]"
+      echo
+      echo "-h, --help                show help"
+      echo "-e, --endpoint <path>     test endpoints starting with the given path"
+      exit 0
+      ;;
+    -e|--endpoint)
+      if [ ! -z $2 ]; then
+        endpoint_flag="-E $2 "
+      else
+        echo "No Endpoint Specified"
+        exit 1
+      fi
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ -z "$(docker-compose ps -q)" ]]; then
+  announce "Environment not found. Spinning up..."
+  ./bin/start_conjur 1> /dev/null
+  echo
+fi
+
+announce "Building API test container image..."
+docker-compose build test-api
+echo
+
+announce "Configuring Conjur Environment..."
+export CONJUR_ADMIN_API_KEY="$(docker-compose exec conjur conjurctl role retrieve-key dev:user:admin | tr -d '\r')"
+export ENCODED_LOGIN="$(echo "admin:${CONJUR_ADMIN_API_KEY}" | base64 | tr -d '\r')"
+export CONJUR_ADMIN_TOKEN="$(curl --header "Accept-Encoding: base64" --data "${CONJUR_ADMIN_API_KEY}" http://localhost/authn/dev/admin/authenticate | tr -d '\r')"
+echo
+
+announce "Running example in container..."
+docker-compose run --rm --no-deps \
+    -e CONJUR_ADMIN_API_KEY=${CONJUR_ADMIN_API_KEY} \
+    test-api \
+    bash -c \
+    "schemathesis run \
+    --show-errors-tracebacks \
+    --hypothesis-deadline None \
+    --request-tls-verify /config/ca.crt \
+    -c all ${endpoint_flag}\
+    -H \"Authorization: Basic \"$ENCODED_LOGIN\"\" \
+    -H \"Authentication: Token token=\"$CONJUR_ADMIN_TOKEN\"\" \
+    --base-url https://conjur-https conjur-openapi.yml"

--- a/conjur-openapi.yml
+++ b/conjur-openapi.yml
@@ -238,10 +238,14 @@ components:
           schema:
             type: string
             example: '14m9cf91wfsesv1kkhevg12cdywm2wvqy6s8sk53z1ngtazp1t9tykc'
+    BadRequest:
+      description: "The server cannot process the request due to malformed request syntax"
     Busy:
       description: "Similar operation already in progress, retry after a delay"
     InadequatePrivileges:
       description: "The authenticated user lacks the necessary privileges"
+    InternalServerError:
+      description: "Malfromed request, rejected by the server"
     LoadedPolicy:
       description: "Decsribes new data created by a successful policy load"
       content:
@@ -258,8 +262,6 @@ components:
                 },
                 "version": 1
               }
-    MissingOrBadRequestParameters:
-      description: "A request parameter was missing or invalid"
     PermissionCheckSuccess:
       description: "Permissions check was successful"
     PublicKeys:
@@ -293,10 +295,8 @@ components:
               }
     UnauthorizedError:
       description: "Authentication information is missing or invalid"
-      headers:
-        WWW_Authenticate:
-          schema:
-            type: string
+    UnprocessableEntity:
+      description: "A request parameter was either missing or invalid."
 
   securitySchemes:
     basicAuth:
@@ -334,11 +334,19 @@ paths:
         required: true
         schema:
           $ref: '#/components/schemas/AccountName'
+
       responses:
         "200":
           $ref: '#/components/responses/ApiKey'
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
+        "422":
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
       security:
         - basicAuth: []
 
@@ -382,11 +390,17 @@ paths:
           text/plain:
             schema:
               $ref: '#/components/schemas/ApiKey'
+
       responses:
         "200":
           $ref: '#/components/responses/AccessTokenGeneric'
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
       security:
         - conjurAuth: []
 
@@ -423,12 +437,17 @@ paths:
       responses:
         "204":
           description: "The password has been changed"
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "404":
           description: "The user was not found"
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
       security:
         - basicAuth: []
 
@@ -465,8 +484,15 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/ApiKey'
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
+        "422":
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
       security:
         - basicAuth: []
           conjurAuth: []
@@ -514,12 +540,16 @@ paths:
       responses:
         "201":
           description: "The secret value was added successfully"
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "403":
           $ref: '#/components/responses/InadequatePrivileges'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -564,6 +594,8 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/SecretValue'
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "403":
@@ -571,7 +603,9 @@ paths:
         "404":
           $ref: '#/components/responses/ResourceNotFound'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -601,7 +635,9 @@ paths:
         "404":
           $ref: '#/components/responses/ResourcesNotFound'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -653,6 +689,8 @@ paths:
       responses:
         "201":
           $ref: '#/components/responses/LoadedPolicy'
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "403":
@@ -662,7 +700,9 @@ paths:
         "409":
           $ref: '#/components/responses/Busy'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -712,6 +752,8 @@ paths:
       responses:
         "201":
           $ref: '#/components/responses/LoadedPolicy'
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "403":
@@ -721,7 +763,9 @@ paths:
         "409":
           $ref: '#/components/responses/Busy'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -772,6 +816,8 @@ paths:
       responses:
         "201":
           $ref: '#/components/responses/LoadedPolicy'
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "403":
@@ -781,7 +827,9 @@ paths:
         "409":
           $ref: '#/components/responses/Busy'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -870,12 +918,16 @@ paths:
             application/json:
               schema:
                 type: object
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "403":
           $ref: '#/components/responses/InadequatePrivileges'
         "404":
           $ref: '#/components/responses/ResourceNotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -946,8 +998,12 @@ paths:
             application/json:
               schema:
                 type: object
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -1015,6 +1071,8 @@ paths:
                 type: object
         "204":
           $ref: '#/components/responses/PermissionCheckSuccess'
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "403":
@@ -1022,7 +1080,10 @@ paths:
         "404":
           $ref: '#/components/responses/ResourceNotFound'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
       security:
         - conjurAuth: []
 
@@ -1059,12 +1120,16 @@ paths:
             application/json:
               schema:
                 type: object
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
         "403":
           $ref: '#/components/responses/InadequatePrivileges'
         "404":
           $ref: '#/components/responses/ResourceNotFound'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -1095,13 +1160,18 @@ paths:
           text/plain:
             schema:
               type: string
+
       responses:
         "204":
           description: "Token was successfully revoked"
+        "400":
+          $ref: '#/components/responses/BadRequest'
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "404":
           $ref: '#/components/responses/ResourceNotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
       security:
         - conjurAuth: []
@@ -1126,6 +1196,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/CreateHostRequest'
+
       responses:
         "201":
           description: "The response body contains the newly-created host"
@@ -1136,7 +1207,10 @@ paths:
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "422":
-          $ref: '#/components/responses/MissingOrBadRequestParameters'
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
       security:
         - conjurAuth: []
 
@@ -1177,6 +1251,14 @@ paths:
       responses:
         "200":
           $ref: '#/components/responses/PublicKeys'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/ResourceNotFound'
+        "422":
+          $ref: '#/components/responses/UnprocessableEntity'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
 # TODO: Inject client cert
 # TODO: Seed Service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,19 @@ services:
       - conjur-https
     volumes:
       - .:/opt/conjur-openapi-spec
+
+  test-api:
+    build:
+      context: .
+      dockerfile: test/Dockerfile.api
+    command: ['sleep', '999d']
+    environment:
+      CONJUR_CA_BUNDLE: /config/ca.crt
+    depends_on:
+      - conjur
+      - conjur-https
+    volumes:
+      - ./config/https/:/config
   
   example-ruby:
     build:

--- a/test/Dockerfile.api
+++ b/test/Dockerfile.api
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+
+WORKDIR /cyberark
+
+RUN apt-get update && \
+    apt-get install -y build-essential \
+                       python3 \
+                       python3-dev \
+                       python3-pip
+
+COPY ./conjur-openapi.yml .
+
+RUN pip3 install schemathesis


### PR DESCRIPTION
### What does this PR do?
This PR sets up Schemathesis tests to the OpenAPI project.
Schemathesis generates and executes test cases for each 
Conjur OSS endpoint, ensuring that the server and the OpenAPI 
spec are compliant. 

By default, tests are run on every endpoint in the spec, however 
a target endpoint can be specified to reduce scope.
This makes it easy to test new endpoints - add the endpoint, 
run the API test.

The test run is containerized, and included in the current 
`docker-compose` environment.

### What ticket does this PR close?
Resolves #33

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation

### QUESTIONS TO CONSIDER
For each endpooint, Schemathesis generates tests like so:
- The first test case fills variable data with hard-coded example data provided by the OpenAPI spec.
- The rest of the test cases are filled with random data that meets spec formatting requirements.  

These do a good job of stress testing input validation and response status codes, but has a drawback
in that the test cases are predominantly of the 400+ response status code variety.
It seems like a good next step would be to configure both the environment and the hard-coded 
example data so that the first test case on each endpoint is a successful one, but this leads 
me to a couple of questions.

Would it be better to use a tool like Google's [OpenAPI Test Templates](https://github.com/google/oatts),
which generates test templates based on each endpoint's expected status codes? This wold ensure that 
each endpoint is being tested for each of its possible outcomes. I'm not sure, as using
Schemathesis has already exposed some possible response status codes and headers and that aren't documented.
Edit: oatts does not support OpenAPI 3.x

Schemathesis seems limited in the way that it can test endpoints for their 200-level responses.
Are these cases adequately tested in the current integration tests? They seem to test the API spec with
the intention of confirming successful requests with expected responses.