### PR TITLE
Made tests reload the default policy for conjur on exit

### DIFF
--- a/test/python/api_config.py
+++ b/test/python/api_config.py
@@ -15,6 +15,11 @@ CONJUR_AUTHN_API_KEY = 'CONJUR_AUTHN_API_KEY'
 CONJUR_AUTHN_LOGIN = 'CONJUR_AUTHN_LOGIN'
 CONJUR_ACCOUNT = 'CONJUR_ACCOUNT'
 
+def get_default_policy():
+    """Gets the default testing policy"""
+    with open(pathlib.Path('.').resolve() / 'test/config/policy.yaml', 'r') as default_policy:
+        return default_policy.read()
+
 def get_api_config():
     """Gets a default API config to be used with the testsing setup"""
     config = openapi_client.Configuration(
@@ -56,4 +61,9 @@ class ConfiguredTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # reload the default policy so tests dont interfere with eachother
+        default_policy = get_default_policy()
+        policy_api = openapi_client.api.policies_api.PoliciesApi(cls.client)
+        policy_api.load_policy(cls.account, 'root', default_policy)
+
         cls.client.close()

--- a/test/python/test_authn_api.py
+++ b/test/python/test_authn_api.py
@@ -9,16 +9,18 @@ import openapi_client
 from . import api_config
 from .api_config import CONJUR_AUTHN_API_KEY, CONJUR_ACCOUNT
 
-class TestAuthnApi(unittest.TestCase):
+class TestAuthnApi(api_config.ConfiguredTest):
     """AuthnApi integration tests. Ensures that authentication with a Conjur server is working"""
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.api_key = os.environ[CONJUR_AUTHN_API_KEY]
         cls.account = os.environ[CONJUR_ACCOUNT]
 
     @classmethod
     def tearDownClass(cls):
+        super().tearDownClass()
         # ensures that the proper API key is set for other test cases after the key rotation test
         os.environ.update({CONJUR_AUTHN_API_KEY: cls.api_key})
 


### PR DESCRIPTION
### What does this PR do?
Made tests reload the default policy on exit so tests don't interfere with eachother

### What ticket does this PR close?
Resolves #82

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
