### PR TITLE
Made swagger editor launch with spec file open by default

### DIFF
--- a/bin/start_editor
+++ b/bin/start_editor
@@ -9,7 +9,7 @@ docker stop swagger-editor || true
 docker rm swagger-editor || true
 
 echo "Starting Swagger editor on port 9090..."
-docker run -d -p 9090:8080 --name swagger-editor swaggerapi/swagger-editor
+docker run -d -p 9090:8080 -v $(pwd):/tmp -e SWAGGER_FILE=/tmp/spec/openapi.yml --name swagger-editor swaggerapi/swagger-editor
 
 echo -n "Waiting for editor to start..."
 until [ "$(docker inspect -f {{.State.Running}} swagger-editor)"=="true" ]; do


### PR DESCRIPTION
Makes editing easier, means you do not need to import the file each time you restart the editor

### What does this PR do?
Changed launch variables for swagger editor container to make the spec file open by default

### What ticket does this PR close?
Resolves #96 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
