### PR TITLE
Secrets expiry endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cybeark/conjur-openapi-spec#62](https://github.com/cyberark/conjur-openapi-spec/issues/62)
 - The authenticators index endpoint is now included in the spec file. Allows users to check which authenticators are installed and enabled.
   [cyberark/conjur-openapi-spec#58](https://github.com/cyberark/conjur-openapi-spec/issues/58)
+- Secrets endpoint will now except `expirations` as an extra kwarg. Allows for resetting the expiration date of a secret.
+  [cybeark/conjur-openapi-spec#64](https://github.com/cyberark/conjur-openapi-spec/issues/64)
+- Secrets endpoint integration tests are now fully enumerated
+  [cyberark/conjur-openapi-spec#102](https://github.com/cyberark/conjur-openapi-spec/issues/102)

--- a/spec/secrets.yml
+++ b/spec/secrets.yml
@@ -52,9 +52,15 @@ components:
           required: true
           schema:
             $ref: 'openapi.yml#/components/schemas/ResourceID'
+        - name: "expirations"
+          in: "query"
+          description: "Tells the server to reset the variables expiration date"
+          required: false
+          schema:
+            type: string
         requestBody:
           description: "Secret data"
-          required: true
+          required: false
           content:
             text/plain:
               schema:
@@ -72,8 +78,6 @@ components:
             $ref: 'openapi.yml#/components/responses/InadequatePrivileges'
           "422":
             $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
-          "500":
-            $ref: 'openapi.yml#/components/responses/InternalServerError'
 
         security:
           - conjurAuth: []
@@ -128,8 +132,6 @@ components:
             $ref: 'openapi.yml#/components/responses/ResourceNotFound'
           "422":
             $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
-          "500":
-            $ref: 'openapi.yml#/components/responses/InternalServerError'
 
         security:
           - conjurAuth: []
@@ -160,8 +162,6 @@ components:
             $ref: 'openapi.yml#/components/responses/ResourcesNotFound'
           "422":
             $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
-          "500":
-            $ref: 'openapi.yml#/components/responses/InternalServerError'
 
         security:
           - conjurAuth: []

--- a/test/config/policy.yaml
+++ b/test/config/policy.yaml
@@ -1,2 +1,4 @@
 - !variable one/password
 - !variable testSecret
+
+- !user alice

--- a/test/config/webservice.yml
+++ b/test/config/webservice.yml
@@ -81,5 +81,3 @@
 - !grant
   role: !group conjur/authn-azure/users
   member: !user admin
-
-- !user alice

--- a/test/python/api_config.py
+++ b/test/python/api_config.py
@@ -33,12 +33,7 @@ def get_api_config():
     return config
 
 def get_api_key(username):
-    """Gets the api key for a given username
-
-    In order for this to work admin MUST have permissions on the new user,
-    which wont be true if you simply add a user to the default policy file
-    loaded in at server start
-    """
+    """Gets the api key for a given username"""
     if username == 'admin':
         return os.environ[CONJUR_AUTHN_API_KEY]
     auth_api = openapi_client.api.authn_api.AuthnApi(get_api_client())

--- a/test/python/test_policies_api.py
+++ b/test/python/test_policies_api.py
@@ -37,7 +37,7 @@ class TestPoliciesApi(api_config.ConfiguredTest):
 
         # Sanity check, make sure the new variable is accessable
         secrets = openapi_client.api.secrets_api.SecretsApi(self.client)
-        secrets.create_variable(self.account, 'variable', NEW_VARIABLE, 'random_data')
+        secrets.create_variable(self.account, 'variable', NEW_VARIABLE, body='random_data')
 
     def test_modify_policy(self):
         """Test case for modify_policy
@@ -63,7 +63,7 @@ class TestPoliciesApi(api_config.ConfiguredTest):
         secrets = openapi_client.api.secrets_api.SecretsApi(self.client)
         secret_val = 'new secret value'
 
-        secrets.create_variable(self.account, 'variable', NEW_VARIABLE, secret_val)
+        secrets.create_variable(self.account, 'variable', NEW_VARIABLE, body=secret_val)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/test_secrets_api.py
+++ b/test/python/test_secrets_api.py
@@ -8,54 +8,262 @@ from . import api_config
 
 TEST_VARIABLES = ["one/password", "testSecret"]
 
+GRANT_POLICY = f"""
+- !permit
+  role: !user alice
+  privileges: [ read ]
+  resource: !variable {TEST_VARIABLES[0]}
+"""
 
 class TestSecretsApi(api_config.ConfiguredTest):
     """SecretsApi unit test stubs"""
     def setUp(self):
         self.api = openapi_client.api.secrets_api.SecretsApi(self.client)
+        self.bad_auth_api = openapi_client.api.secrets_api.SecretsApi(self.bad_auth_client)
 
-    def test_create_variable(self):
-        """Test case for create_variable
+    def grant_insufficient_permissions(self):
+        """Loads a policy with incorrect permissions on a secret so we can retrieve
+        a 403 error when we try to manipulate it"""
+        policy_api = openapi_client.api.PoliciesApi(self.client)
+
+        policy_api.modify_policy(self.account, 'root', GRANT_POLICY)
+
+    def test_create_variable_201(self):
+        """Test case for create_variable response 201
 
         Creates a secret value within the specified variable.
         """
         secret_val = "this is a secret"
 
-        self.api.create_variable(self.account, "variable", TEST_VARIABLES[0], secret_val)
+        resp = self.api.create_variable_with_http_info(
+            self.account,
+            "variable",
+            TEST_VARIABLES[0],
+            body=secret_val
+        )
+        self.assertEqual(resp[1], 201)
 
-    def test_get_variable(self):
-        """Test case for get_variable
+    def test_create_variable_401(self):
+        """Test case for create_variable response 401"""
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.bad_auth_api.create_variable(
+                self.account,
+                "variable",
+                TEST_VARIABLES[0],
+                body='test'
+            )
+
+        self.assertEqual(context.exception.status, 401)
+
+    def test_create_variable_403(self):
+        """Test case for create_variable response 403"""
+        alice_client = api_config.get_api_client(username='alice')
+        alice_api = openapi_client.api.SecretsApi(alice_client)
+        secret_val = "this is a secret"
+        self.grant_insufficient_permissions()
+
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            alice_api.create_variable(self.account, "variable", TEST_VARIABLES[0], body=secret_val)
+
+        self.assertEqual(context.exception.status, 403)
+
+    def test_create_variable_422(self):
+        """Test case for create_variable response 422"""
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.api.create_variable(self.account, "variable", TEST_VARIABLES[0], body="")
+
+        self.assertEqual(context.exception.status, 422)
+
+    def test_create_variable_expirations_201(self):
+        """Test case for create_variable with expirations query parameter 201 response code"""
+        _, status, _ = self.api.create_variable_with_http_info(
+            self.account,
+            "variable",
+            TEST_VARIABLES[0],
+            expirations="",
+            body=""
+        )
+
+        self.assertEqual(status, 201)
+
+    def test_create_variable_expirations_401(self):
+        """Test case for create_variable with expirations query parameter 401 response code"""
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.bad_auth_api.create_variable(
+                self.account,
+                "variable",
+                TEST_VARIABLES[0],
+                expirations="",
+                body=""
+            )
+
+        self.assertEqual(context.exception.status, 401)
+
+    def test_create_variable_expirations_403(self):
+        """Test case for create_variable with expirations query parameter 403 response code"""
+        alice_client = api_config.get_api_client(username='alice')
+        alice_api = openapi_client.api.SecretsApi(alice_client)
+        self.grant_insufficient_permissions()
+
+        with self.assertRaises(openapi_client.ApiException) as context:
+            alice_api.create_variable(
+                self.account,
+                "variable",
+                TEST_VARIABLES[0],
+                expirations="",
+                body=""
+            )
+
+        self.assertEqual(context.exception.status, 403)
+
+    def test_create_variable_expirations_404(self):
+        """Test case for create_variable with expirations query parameter 404 response code"""
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.create_variable(
+                self.account,
+                "variable",
+                'nonexist',
+                expirations="",
+                body=""
+            )
+
+        self.assertEqual(context.exception.status, 404)
+
+    def test_get_variable_version_200(self):
+        """Test case for get_variable 200 response with version parameter
 
         Fetches the value of a secret from the specified Variable.
         """
         secret_val = "secret data"
-        self.api.create_variable(self.account, "variable", TEST_VARIABLES[0], secret_val)
+        self.api.create_variable(self.account, "variable", TEST_VARIABLES[0], body=secret_val)
 
-        response = self.api.get_variable(self.account, "variable", TEST_VARIABLES[0])
-        self.assertEqual(secret_val, response)
+        response = self.api.get_variable_with_http_info(
+            self.account,
+            "variable",
+            TEST_VARIABLES[0],
+            version='2'
+        )
+        self.assertEqual(secret_val, response[0])
+        self.assertEqual(response[1], 200)
 
-        secret_val = "new value"
-        self.api.create_variable(self.account, "variable", TEST_VARIABLES[0], secret_val)
+    def test_get_variable_200(self):
+        """Test case for get_variable 200 response
 
-        response = self.api.get_variable(self.account, "variable", TEST_VARIABLES[0])
-        self.assertEqual(secret_val, response)
+        Fetches the value of a secret from the specified Variable.
+        """
+        secret_val = "secret data"
+        self.api.create_variable(self.account, "variable", TEST_VARIABLES[0], body=secret_val)
 
-    def test_get_variables(self):
-        """Test case for get_variables
+        response = self.api.get_variable_with_http_info(self.account, "variable", TEST_VARIABLES[0])
+        self.assertEqual(secret_val, response[0])
+        self.assertEqual(response[1], 200)
+
+    def test_get_variable_401(self):
+        """Test case for get_variable 401 response with version parameter
+
+        Fetches the value of a secret from the specified Variable.
+        """
+        secret_val = "secret data"
+        self.api.create_variable(self.account, "variable", TEST_VARIABLES[0], body=secret_val)
+
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.bad_auth_api.get_variable(self.account, "variable", TEST_VARIABLES[0], version=1)
+
+        self.assertEqual(context.exception.status, 401)
+
+    def test_get_variable_version_401(self):
+        """Test case for get_variable 401 response"""
+        secret_val = "secret data"
+        self.api.create_variable(self.account, "variable", TEST_VARIABLES[0], body=secret_val)
+
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.bad_auth_api.get_variable(self.account, "variable", TEST_VARIABLES[0])
+
+        self.assertEqual(context.exception.status, 401)
+
+    def test_get_variable_403(self):
+        """Test case for get_variable 403 response"""
+        alice_client = api_config.get_api_client(username='alice')
+        alice_api = openapi_client.api.SecretsApi(alice_client)
+        self.grant_insufficient_permissions()
+
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            alice_api.get_variable(self.account, "variable", TEST_VARIABLES[0])
+
+        self.assertEqual(context.exception.status, 403)
+
+    def test_get_variable_404(self):
+        """Test case for get_variable 404 response"""
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.api.get_variable(self.account, "variable", "badname")
+
+        self.assertEqual(context.exception.status, 404)
+
+    def test_get_variable_422(self):
+        """Test case for get_variable 422 response"""
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.api.get_variable(self.account, "variable", TEST_VARIABLES[0], version='')
+
+        self.assertEqual(context.exception.status, 422)
+
+    def test_get_variables_200(self):
+        """Test case for get_variables 200 response
 
         Fetch multiple secrets
         """
         secret_values = ['one', 'two']
         for secret, value in zip(TEST_VARIABLES, secret_values):
-            self.api.create_variable(self.account, "variable", secret, value)
+            self.api.create_variable(self.account, "variable", secret, body=value)
 
         # Secrets have to be in the format org:variable:secret_name
         secret_list = [f"dev:variable:{i}" for i in TEST_VARIABLES]
-        response = self.api.get_variables(",".join(secret_list))
+        response, status, _ = self.api.get_variables_with_http_info(
+            ",".join(secret_list)
+        )
 
+        self.assertEqual(status, 200)
         for secret, value in zip(secret_list, secret_values):
             self.assertIn(secret, response)
             self.assertEqual(response[secret], value)
+
+    def test_get_variables_401(self):
+        """Test case for get_variables 401 response"""
+        secret_list = ','.join([f"dev:variable:{i}" for i in TEST_VARIABLES])
+
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.bad_auth_api.get_variables(secret_list)
+
+        self.assertEqual(context.exception.status, 401)
+
+    def test_get_variables_403(self):
+        """Test case for get_variables 403 response"""
+        self.grant_insufficient_permissions()
+        alice_client = api_config.get_api_client(username='alice')
+        alice_api = openapi_client.api.SecretsApi(alice_client)
+        secret_list = ','.join([f"dev:variable:{i}" for i in TEST_VARIABLES])
+
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            alice_api.get_variables(secret_list)
+
+        self.assertEqual(context.exception.status, 403)
+
+    def test_get_variables_404(self):
+        """Test case for get_variables 404 response"""
+        secret_list = f'{self.account}:variable:nonexist'
+
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.api.get_variables(secret_list)
+
+        self.assertEqual(context.exception.status, 404)
+
+    def test_get_variables_422(self):
+        """Test case for get_variables 422 response"""
+        secret_list = "\00"
+
+        with self.assertRaises(openapi_client.exceptions.ApiException) as context:
+            self.api.get_variables(secret_list)
+
+        self.assertEqual(context.exception.status, 422)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/test_status_api.py
+++ b/test/python/test_status_api.py
@@ -40,13 +40,13 @@ class TestStatusApi(api_config.ConfiguredTest):
             cls.account,
             "variable",
             'conjur/authn-oidc/okta/provider-uri',
-            'invalid'
+            body='invalid'
         )
         secrets_api.create_variable(
             cls.account,
             "variable",
             'conjur/authn-oidc/okta/id-token-user-property',
-            'admin'
+            body='admin'
         )
 
     @classmethod


### PR DESCRIPTION
### What does this PR do?
Added `expires` keyword to secrets endpoint. Also added expanded integration tests for secrets endpoint

### What ticket does this PR close?
Resolves #64 #102

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation

NOTE: All calls with the expirations query parameter are required to also specify an empty body (in the generated python client). This is due to an issue on the [openapi generated](https://github.com/OpenAPITools/openapi-generator/issues/8300) client which I am currently working on fixing.
