### PR TITLE
Update Roles API Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-openapi-spec#102](https://github.com/cyberark/conjur-openapi-spec/issues/102)
 - Adding and deleting role members now supported in Roles spec file.
   [cyberark/conjur-openapi-spec#65](https://github.com/cyberark/conjur-openapi-spec/issues/65)
+- `memberships` query parameter supported on Roles endpoint.
+  [cybeark/conjur-openapi-spec#67](https://github.com/cyberark/conjur-openapi-spec/issues/67)
+- `all` query parameter supported on Roles endpoint.
+  [cybeark/conjur-openapi-spec#68](https://github.com/cyberark/conjur-openapi-spec/issues/68)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cybeark/conjur-openapi-spec#64](https://github.com/cyberark/conjur-openapi-spec/issues/64)
 - Secrets endpoint integration tests are now fully enumerated
   [cyberark/conjur-openapi-spec#102](https://github.com/cyberark/conjur-openapi-spec/issues/102)
+- Adding and deleting role members now supported in Roles spec file.
+  [cyberark/conjur-openapi-spec#65](https://github.com/cyberark/conjur-openapi-spec/issues/65)

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -151,6 +151,8 @@ components:
       description: "The server cannot process the request due to malformed request syntax"
     Busy:
       description: "Similar operation already in progress, retry after a delay"
+    DeleteMemberSuccess:
+      description: "Member was deleted from role successfully"
     InadequatePrivileges:
       description: "The authenticated user lacks the necessary privileges"
     InternalServerError:

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -138,6 +138,8 @@ components:
         text/plain:
           schema:
             type: string
+    AddMemberSuccess:
+      description: "Member was added to role successfully"
     ApiKey:
       description: "The response body is the API key"
       content:
@@ -159,6 +161,18 @@ components:
       description: "The requested resource does not exist, the authenticated user lacks the required privileges to enumerate this resource, or its value has not been set"
     ResourcesNotFound:
       description: "At least one resource was unable to be found"
+    Roles:
+      description: "The response body contains the requested role(s)/member(s)"
+      content:
+        application/json:
+          schema:
+            type: object
+            example:
+              {
+                "created_at": "2020-12-31:12:34:56.789+00:00",
+                "id": "myorg:user:admin",
+                "members": []
+              }
     SecretValue:
       description: "The secret value was added successfully"
       content:

--- a/spec/roles.yml
+++ b/spec/roles.yml
@@ -8,27 +8,19 @@ components:
         summary: "Get role information"
         description: "Gets detailed information about a specific role, including the role members.
 
-
           If a role A is granted to a role B, then role A is said to have role B as a member. These relationships are described in the “members” portion of the returned JSON.
 
-
-          openapi.yml#openapi.yml#openapi.yml#openapi.yml#openapi.yml# Listing members
-
+          ##### Listing members
 
           If `members` is provided, you will get the members of a role.
 
-
           If a `kind` query parameter is given, narrows results to only resources of that kind.
-
 
           If a `limit` is given, returns no more than that number of results. Providing an `offset` skips a number of resources before returning the rest. In addition, providing an `offset` will give limit a default value of 10 if none other is provided. These two parameters can be combined to page through results.
 
-
           If the parameter `count` is true, returns only the number of items in the list.
 
-
-          openapi.yml#openapi.yml#openapi.yml#openapi.yml#openapi.yml# Text search
-
+          ##### Text search
 
           If the search parameter is provided, narrows results to those pertaining to the search query. Search works across resource IDs and the values of annotations. It weights results so that those with matching id or a matching value of an annotation called name appear first, then those with another matching annotation value, and finally those with a matching kind.
           "
@@ -56,10 +48,9 @@ components:
             $ref: 'openapi.yml#/components/schemas/ResourceID'
         - name: "members"
           in: "query"
-          description: "Comma-delimited, URL-encoded resource IDs of the variables."
+          description: "Returns a list of the Role's members."
           schema:
-            type: boolean
-            example: false
+            type: string
         - name: "offset"
           in: "query"
           description: "When listing members, start at this item number."
@@ -75,14 +66,17 @@ components:
           description: "When listing members, if `true`, return only the count of members."
           schema:
             $ref: 'openapi.yml#/components/schemas/Count'
+        - name: "search"
+          in: "query"
+          description: "When listing members, the results will be narrowed to only those matching the provided string"
+          schema:
+            type: string
+            minLength: 1
+            example: "user"
 
         responses:
-          "201":
-            description: "The response body contains the requested role(s)/member(s)"
-            content:
-              application/json:
-                schema:
-                  type: object
+          "200":
+            $ref: 'openapi.yml#/components/responses/Roles'
           "400":
             $ref: 'openapi.yml#/components/responses/BadRequest'
           "401":
@@ -91,6 +85,75 @@ components:
             $ref: 'openapi.yml#/components/responses/InadequatePrivileges'
           "404":
             $ref: 'openapi.yml#/components/responses/ResourceNotFound'
+          "422":
+            $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
+          "500":
+            $ref: 'openapi.yml#/components/responses/InternalServerError'
+
+        security:
+          - conjurAuth: []
+
+      post:
+        tags:
+        - "roles"
+        summary: "Update or modify an existing role membership"
+        description: "Updates or modifies an existing role membership.
+
+          If a role A is granted to a role B, then role A is said to have role B as a member. These relationships are described in the “members” portion of the returned JSON.
+
+          When the `members` query parameter is provided, you will get the members of a role.
+
+          When the `members` and `member` query parameters are provided, the role specfified by `member` will be added as a member of the role specified in the endpoint URI.
+          "
+        operationId: "addMember"
+        parameters:
+        - name: "account"
+          in: "path"
+          description: "Organization account name"
+          required: true
+          schema:
+            $ref: 'openapi.yml#/components/schemas/AccountName'
+        - name: "kind"
+          in: "path"
+          description: "Type of resource"
+          required: true
+          example: user
+          schema:
+            $ref: 'openapi.yml#/components/schemas/Kind'
+        - name: "identifier"
+          in: "path"
+          description: "ID of the role for which to get the information about"
+          required: true
+          example: "admin"
+          schema:
+            $ref: 'openapi.yml#/components/schemas/ResourceID'
+        - name: "members"
+          in: "query"
+          description: "Returns a list of the Role's members."
+          required: true
+          schema:
+            type: string
+        - name: "member"
+          in: "query"
+          description: "The identifier of the Role to be added as a member."
+          required: true
+          schema:
+            $ref: 'openapi.yml#/components/schemas/Role'
+
+
+        responses:
+          "204":
+            $ref: 'openapi.yml#/components/responses/AddMemberSuccess'
+          "400":
+            $ref: 'openapi.yml#/components/responses/BadRequest'
+          "401":
+            $ref: 'openapi.yml#/components/responses/UnauthorizedError'
+          "403":
+            $ref: 'openapi.yml#/components/responses/InadequatePrivileges'
+          "404":
+            $ref: 'openapi.yml#/components/responses/ResourceNotFound'
+          "422":
+            $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
           "500":
             $ref: 'openapi.yml#/components/responses/InternalServerError'
 

--- a/spec/roles.yml
+++ b/spec/roles.yml
@@ -87,8 +87,6 @@ components:
             $ref: 'openapi.yml#/components/responses/ResourceNotFound'
           "422":
             $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
-          "500":
-            $ref: 'openapi.yml#/components/responses/InternalServerError'
 
         security:
           - conjurAuth: []
@@ -154,8 +152,71 @@ components:
             $ref: 'openapi.yml#/components/responses/ResourceNotFound'
           "422":
             $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
-          "500":
-            $ref: 'openapi.yml#/components/responses/InternalServerError'
+
+        security:
+          - conjurAuth: []
+
+      delete:
+        tags:
+        - "roles"
+        summary: "Deletes an existing role membership"
+        description: "Deletes an existing role membership.
+
+          If a role A is granted to a role B, then role A is said to have role B as a member. These relationships are described in the “members” portion of the returned JSON.
+
+          When the `members` query parameter is provided, you will get the members of a role.
+
+          When the `members` and `member` query parameters are provided, the role specfified by `member` will be removed as a member of the role specified in the endpoint URI.
+          "
+        operationId: "deleteMember"
+        parameters:
+        - name: "account"
+          in: "path"
+          description: "Organization account name"
+          required: true
+          schema:
+            $ref: 'openapi.yml#/components/schemas/AccountName'
+        - name: "kind"
+          in: "path"
+          description: "Type of resource"
+          required: true
+          example: user
+          schema:
+            $ref: 'openapi.yml#/components/schemas/Kind'
+        - name: "identifier"
+          in: "path"
+          description: "ID of the role for which to get the information about"
+          required: true
+          example: "admin"
+          schema:
+            $ref: 'openapi.yml#/components/schemas/ResourceID'
+        - name: "members"
+          in: "query"
+          description: "Returns a list of the Role's members."
+          required: true
+          schema:
+            type: string
+        - name: "member"
+          in: "query"
+          description: "The identifier of the Role to be added as a member."
+          required: true
+          schema:
+            $ref: 'openapi.yml#/components/schemas/Role'
+
+
+        responses:
+          "204":
+            $ref: 'openapi.yml#/components/responses/DeleteMemberSuccess'
+          "400":
+            $ref: 'openapi.yml#/components/responses/BadRequest'
+          "401":
+            $ref: 'openapi.yml#/components/responses/UnauthorizedError'
+          "403":
+            $ref: 'openapi.yml#/components/responses/InadequatePrivileges'
+          "404":
+            $ref: 'openapi.yml#/components/responses/ResourceNotFound'
+          "422":
+            $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
 
         security:
           - conjurAuth: []

--- a/spec/roles.yml
+++ b/spec/roles.yml
@@ -46,6 +46,16 @@ components:
           example: "admin"
           schema:
             $ref: 'openapi.yml#/components/schemas/ResourceID'
+        - name: "all"
+          in: "query"
+          description: "Returns all role memberships, expanded recursively."
+          schema:
+            type: string
+        - name: "memberships"
+          in: "query"
+          description: "Returns all direct role memberships (members not expanded recursively)."
+          schema:
+            type: string
         - name: "members"
           in: "query"
           description: "Returns a list of the Role's members."

--- a/test/python/api_config.py
+++ b/test/python/api_config.py
@@ -74,8 +74,15 @@ class ConfiguredTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         # reload the default policy so tests dont interfere with eachother
+        cls.load_default_policy()
+
+        cls.client.close()
+
+    @classmethod
+    def load_default_policy(cls):
+        """Reloads a default policy
+        Compartmentalizes test cases by replacing any loaded policy
+        """
         default_policy = get_default_policy()
         policy_api = openapi_client.api.policies_api.PoliciesApi(cls.client)
         policy_api.load_policy(cls.account, 'root', default_policy)
-
-        cls.client.close()

--- a/test/python/test_roles_api.py
+++ b/test/python/test_roles_api.py
@@ -6,22 +6,345 @@ import openapi_client
 
 from . import api_config
 
+ROLES_POLICY = """
+- !group
+  id: userGroup
+  annotations:
+    editable: true
+
+- !user bob
+- !user alice
+"""
+
+NULL_BYTE = '\00'
+
 class TestRolesApi(api_config.ConfiguredTest):
     """RolesApi unit test stubs"""
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ADMIN_ID = f'{cls.account}:user:admin'
+        cls.ALICE_ID = f'{cls.account}:user:alice'
+        cls.BOB_ID   = f'{cls.account}:user:bob'
+        cls.GROUP_ID = f'{cls.account}:group:userGroup'
+        cls.ROOT_ID  = f'{cls.account}:policy:root'
+
     def setUp(self):
-        self.api = openapi_client.api.roles_api.RolesApi(self.client)
+        self.api = openapi_client.RolesApi(self.client)
+        self.bad_auth_api = openapi_client.RolesApi(self.bad_auth_client)
 
-    def test_get_role(self):
-        """Test case for get_role
+        # set a new root policy including a new group and users Alice and Bob
+        # these will be used to test member addition/deletion
+        policy_api = openapi_client.PoliciesApi(self.client)
+        policy_api.load_policy(self.account, 'root', ROLES_POLICY)
 
-        Get role information
+    def tearDown(self):
+        super().load_default_policy()
+
+    def add_user_to_group(self, identifier):
+        """Adds a given user to the group defined in ROLES_POLICY
         """
-        details = self.api.get_role(self.account, 'user', 'admin')
+        role_id = f'{self.account}:user:{identifier}'
+        response = self.api.add_member_with_http_info(
+            self.account,
+            'group',
+            'userGroup',
+            members='',
+            member=role_id
+        )
+        return response
 
-        self.assertIsInstance(details, dict)
+    # Test cases for GET requests to /roles/{account}/{kind}/{identifier} endpoint
+
+    def test_get_role_200(self):
+        """Test case for 200 status response when getting role data
+        Gets information on the specified role
+        """
+        role_details, status, _ = self.api.get_role_with_http_info(self.account, 'user', 'admin')
+
+        self.assertEqual(status, 200)
+        self.assertIsInstance(role_details, dict)
         members = ['created_at', 'id', 'members']
         for i in members:
-            self.assertIn(i, details)
+            self.assertIn(i, role_details)
+
+    def test_get_role_400(self):
+        """Test case for 400 status repsonse when getting role data
+        Error originates from NGINX, occurs when making HTTPS requests to Conjur through NGINX
+        This same request made directly to Conjur with HTTP results in a 422 status response
+        400 - request rejected by NGINX proxy
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.get_role(self.account, NULL_BYTE, 'admin')
+
+        self.assertEqual(context.exception.status, 400)
+
+    def test_get_role_401(self):
+        """Test case for 401 status response when getting role data
+        401 - unauthorized request
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.bad_auth_api.get_role(self.account, 'user', 'admin')
+
+        self.assertEqual(context.exception.status, 401)
+
+    def test_get_role_404(self):
+        """Test case for 404 status response when getting role data
+        404 - the role could not be found
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.get_role(self.account, 'user', 'fakeUser')
+
+        self.assertEqual(context.exception.status, 404)
+
+    def test_get_role_422(self):
+        """Test case for 422 status response when getting role data
+        422 - Conjur recieved a malformed request parameter
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.get_role(
+                self.account,
+                'user',
+                'admin',
+                members='',
+                search=NULL_BYTE
+            )
+
+        self.assertEqual(context.exception.status, 422)
+
+    # Test query parameters on GET requests to /roles/{account}/{kind}/{identifier} endpoint
+
+    def test_get_members(self):
+        """Test using members query parameter on GET requests
+        Queries group:userGroup role for its members, which should only be dev:user:admin
+        """
+        response = self.api.get_role(
+            self.account,
+            'group',
+            'userGroup',
+            members=''
+        )
+
+        target_response = [
+            {
+                'admin_option': True,
+                'ownership': True,
+                'role': self.GROUP_ID,
+                'member': self.ADMIN_ID,
+                'policy': self.ROOT_ID
+            }
+        ]
+
+        self.assertEqual(response, target_response)
+
+    def test_get_members_count(self):
+        """Test using members & count query parameters on GET
+        Adds dev:user:bob as a member of group:userGroup, then queries for a member count
+        """
+        self.add_user_to_group('bob')
+        self.add_user_to_group('alice')
+
+        response = self.api.get_role(
+            self.account,
+            'group',
+            'userGroup',
+            members='',
+            count=True
+        )
+
+        self.assertEqual(response['count'], 3)
+
+    def test_get_members_offset(self):
+        """Test using members & offset query parameters on GET requests
+        Returns member data starting at <offset>
+        """
+        self.add_user_to_group('bob')
+        self.add_user_to_group('alice')
+
+        response = self.api.get_role(
+            self.account,
+            'group',
+            'userGroup',
+            members='',
+            offset=2
+        )
+
+        # starting at offset 2 should omit user:admin (0) and user:alice (1)
+        target_response = [
+            {
+                'admin_option': False,
+                'ownership': False,
+                'role': self.GROUP_ID,
+                'member': self.BOB_ID
+            }
+        ]
+
+        self.assertEqual(response, target_response)
+
+    def test_get_members_limit(self):
+        """Test using members & limit query parameters on GET requests
+        Returns member data limited to the first <limit> results
+        """
+        self.add_user_to_group('bob')
+        self.add_user_to_group('alice')
+
+        response = self.api.get_role(
+            self.account,
+            'group',
+            'userGroup',
+            members='',
+            limit=2
+        )
+
+        # limiting the results to the first 2 should omit user:bob (idx 2)
+        target_response = [
+            {
+                'admin_option': True,
+                'ownership': True,
+                'role': self.GROUP_ID,
+                'member': self.ADMIN_ID,
+                'policy': self.ROOT_ID
+            },
+            {
+                'admin_option': False,
+                'ownership': False,
+                'role': self.GROUP_ID,
+                'member': self.ALICE_ID
+            }
+        ]
+
+        self.assertEqual(response, target_response)
+
+    def test_get_members_search(self):
+        """Test using members & search query parameters on GET requests
+        Returns only members matching the provided string
+        """
+        self.add_user_to_group('bob')
+        self.add_user_to_group('alice')
+
+        response = self.api.get_role(
+            self.account,
+            'group',
+            'userGroup',
+            members='',
+            search='bob'
+        )
+
+        target_response = [
+            {
+                'admin_option': False,
+                'ownership': False,
+                'role': self.GROUP_ID,
+                'member': self.BOB_ID
+            }
+        ]
+
+        self.assertEqual(response, target_response)
+
+    # Test cases for POST requests to /roles/{account}/{kind}/{identifier}?members&member="{role}"
+
+    def test_add_member_204(self):
+        """Test case for 204 status response when adding role member
+        This endpoint will assign a given role as a member to another role
+        The example shown here is a user Bob being assigned as a member of a group
+        204 - successful member assignment, empty response body
+        """
+        _, status, _ = self.add_user_to_group('bob')
+        self.assertEqual(status, 204)
+
+        group_member_data = self.api.get_role(
+            self.account,
+            'group',
+            'userGroup',
+            members=''
+        )
+
+        self.assertEqual(len(group_member_data), 2)
+        members = [self.ADMIN_ID, self.BOB_ID]
+        for i in range(0, 2):
+            self.assertEqual(group_member_data[i]['member'], members[i])
+
+    def test_add_member_400(self):
+        """Test case for 400 status response when adding role member
+        Error originates from NGINX, occurs when making HTTPS requests to Conjur through NGINX
+        This same request made directly to Conjur with HTTP results in a 422 status response
+        400 - request rejected by NGINX proxy
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.add_member(
+                self.account,
+                NULL_BYTE,
+                'userGroup',
+                members='',
+                member=self.BOB_ID
+            )
+
+        self.assertEqual(context.exception.status, 400)
+
+    def test_add_member_401(self):
+        """Test case for 401 status response when adding role member
+        401 - unauthorized request
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.bad_auth_api.add_member(
+                self.account,
+                'group',
+                'userGroup',
+                members='',
+                member=self.BOB_ID
+            )
+
+        self.assertEqual(context.exception.status, 401)
+
+    def test_add_member_403(self):
+        """Test case for 403 status response when adding role member
+        403 - the authenticated user lacks the necessary privilege
+        """
+        # establish a new api client as user Bob
+        bob_client = api_config.get_api_client(username='bob')
+        bob_roles_api = openapi_client.RolesApi(bob_client)
+
+        # attempt to add Alice as a member of userGroup as Bob
+        with self.assertRaises(openapi_client.ApiException) as context:
+            bob_roles_api.add_member(
+                self.account,
+                'group',
+                'userGroup',
+                members='',
+                member=self.ALICE_ID
+            )
+
+        self.assertEqual(context.exception.status, 403)
+
+    def test_add_member_404(self):
+        """Test case for 404 status response when adding role member
+        404 - the role inteded for assignment as member does not exist
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.add_member(
+                self.account,
+                'group',
+                'userGroup',
+                members='',
+                member=f'{self.account}:user:fakeUser'
+            )
+
+        self.assertEqual(context.exception.status, 404)
+
+    def test_add_member_422(self):
+        """Test case for 422 status response when adding role member
+        422 - Conjur recieved a malformed request parameter
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.add_member(
+                self.account,
+                'group',
+                'userGroup',
+                members='',
+                member=NULL_BYTE
+            )
+
+        self.assertEqual(context.exception.status, 422)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What does this PR do?
This PR is intended to update the API spec for Roles endpoints by including definitions and tests
for POST and DELETE requests to `/roles/{account}/{kind}/{identifier}?members&member="{role}"`.

Adds query parameters `all` and `memberships` to Roles spec, and tests each.

DONE:
- `GET /roles/{account}/{kind}/{identifier}`
  - adds query parameters and possible status responses 
  - adds testing for each status response
- `POST /roles/{account}/{kind}/{identifier}?members&member="{role}"`
  - describes the request in the API spec
  - adds tests for each possible status response
- `DELETE /roles/{account}/{kind}/{identifier}?members&member="{role}"`
  - describes the request in the API spec
  - adds tests for each possible status response

### What ticket does this PR close?
Resolves #65 
Resolves #67 
Resolves #68 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
