### PR TITLE
Tests and documents API responses when given multiple optional params

### DIFF
--- a/spec/resources.yml
+++ b/spec/resources.yml
@@ -281,6 +281,12 @@ components:
         summary: "Shows a description of a single resource."
         description: "Details about a single resource.
 
+        If `permitted_roles` and `privilege` are given, Conjur lists the roles with the specified privilege on the resource.
+
+        If `check`, `privilege` and `role` are given, Conjur checks if the specified role has the privilege on the resource.
+
+        If `permitted_roles` and `check` are both given, Conjur responds to the `check` call ONLY.
+
         ##### Permissions Required
 
         `read` privilege on the resource."
@@ -341,6 +347,8 @@ components:
             $ref: 'openapi.yml#/components/responses/BadRequest'
           "401":
             $ref: 'openapi.yml#/components/responses/UnauthorizedError'
+          "403":
+            $ref: 'openapi.yml#/components/responses/InadequatePrivileges'
           "404":
             $ref: 'openapi.yml#/components/responses/ResourceNotFound'
           "422":

--- a/spec/roles.yml
+++ b/spec/roles.yml
@@ -1,4 +1,3 @@
-
 components:
   schemas:
     RolesGraph:
@@ -10,6 +9,7 @@ components:
             $ref: 'openapi.yml#/components/schemas/ResourceID'
           child:
             $ref: 'openapi.yml#/components/schemas/ResourceID'
+
   responses:
     Roles:
       description: "The response body contains the requested role(s)/member(s)"
@@ -23,6 +23,7 @@ components:
                 "id": "myorg:user:admin",
                 "members": []
               }
+
   paths:
     Roles:
       get:
@@ -46,6 +47,15 @@ components:
           ##### Text search
 
           If the search parameter is provided, narrows results to those pertaining to the search query. Search works across resource IDs and the values of annotations. It weights results so that those with matching id or a matching value of an annotation called name appear first, then those with another matching annotation value, and finally those with a matching kind.
+
+          ##### Parameter Priority
+
+          If Conjur is given any combination of optional parameters, it responds with ONLY results for the parameter of the highest priority.
+
+          1. `graph`
+          2. `all`
+          3. `memberships`
+          4. `members`
           "
         operationId: "getRole"
         parameters:
@@ -71,7 +81,7 @@ components:
             $ref: 'openapi.yml#/components/schemas/ResourceID'
         - name: "all"
           in: "query"
-          description: "Returns all role memberships, expanded recursively."
+          description: "Returns an array of Role IDs representing all role memberships, expanded recursively."
           schema:
             type: string
         - name: "memberships"

--- a/test/python/test_resources_api.py
+++ b/test/python/test_resources_api.py
@@ -228,6 +228,22 @@ class TestResourcesApi(api_config.ConfiguredTest):
 
         self.assertEqual(context.exception.status, 401)
 
+    def test_get_resource_403(self):
+        """Test case for 403 status response on /resources/{account}/{kind}/{identifier} endpoint
+        403 - the specified role does not have privilege over the resource
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.get_resource(
+                self.account,
+                'variable',
+                'testSecret',
+                check='',
+                privilege='read',
+                role='user:alice'
+            )
+
+        self.assertEqual(context.exception.status, 403)
+
     def test_get_resource_404a(self):
         """Test case for 404 status response on /resources/{account}/{kind}/{identifier} endpoint
         404 - the requested resource does not exist
@@ -257,6 +273,24 @@ class TestResourcesApi(api_config.ConfiguredTest):
             self.api.get_resource(self.account, 'variable', 'testSecret', check=NULL_BYTE)
 
         self.assertEqual(context.exception.status, 422)
+
+    # Test combinations of optional query parameters when getting a single resource
+
+    def test_permitted_roles_and_check(self):
+        """Test case for using both `permitted_roles` and `check` query parameters
+        When both parameters are used, Conjur responds to the `check` call only
+        """
+        response, status, _ = self.api.get_resource_with_http_info(
+            self.account,
+            'variable',
+            'testSecret',
+            permitted_roles='',
+            check='',
+            privilege='read'
+        )
+
+        self.assertEqual(status, 204)
+        self.assertEqual(response, '')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_
On Roles and Resources endpoints, the behavior of Conjur when given
multiple optional query parameters is unclear. This commit tests
their relationships and defines it in the API spec.

### What ticket does this PR close?
Resolves #114 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
