### PR TITLE
Added GCP authenticate endpoint to spec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-openapi-spec#63](https://github.com/cyberark/conjur-openapi-spec/issues/63)
 - OIDC authenticate endpoint now included in the OpenAPI specification. Users can now authenticate with Conjur through an OIDC provider using a generated client.
   [cyberark/conjur-openapi-spec#60](https://github.com/cyberark/conjur-openapi-spec/issues/60)
+- Google Cloud Provider authenticate endpoint now included in the spec file. Users can now authenticate with Conjur using GCP.
+  [cyberark/conjur-openapi-spec#61](https://github.com/cyberark/conjur-openapi-spec/issues/61)

--- a/spec/authentication.yaml
+++ b/spec/authentication.yaml
@@ -427,7 +427,6 @@ components:
         - "authn"
         summary: "Gets a short-lived access token, which can be used to authenticate requests to (most of) the rest of the Conjur API."
         description: "A client can obtain an access token by presenting a valid OpenID ID token.
-
         The client must first authenticate with the OpenID provider, then pass the id token to the conjur server to
         retrieve an API token"
         operationId: "oidcAuthenticate"
@@ -465,3 +464,44 @@ components:
             $ref: 'openapi.yml#/components/responses/UnauthorizedError'
           "502":
             description: "Error connecting conjur to the OIDC provider"
+
+    GCPAuthenticate:
+      post:
+        tags:
+        - "authn"
+        summary: "Authenticate with Conjur via Google Cloud Platform"
+        description: "A client can obtain an access token by presenting a valid JWT identity token"
+        operationId: "gcpAuthenticate"
+        parameters:
+        - name: "account"
+          in: "path"
+          description: "Organization account name"
+          required: true
+          schema:
+            type: string
+          example: "dev"
+        - name: "Accept-Encoding"
+          in: "header"
+          description: "Setting the Accept-Encoding header to base64 will return a pre-encoded access token"
+          schema:
+            type: string
+            enum: [ "base64" ]
+        requestBody:
+          description: "JWT key for authentication"
+          required: true
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                type: object
+                properties:
+                  jwt:
+                    type: string
+        responses:
+          "200":
+            $ref: 'openapi.yml#/components/responses/ApiKey'
+          "400":
+            $ref: 'openapi.yml#/components/responses/BadRequest'
+          "401":
+            $ref: 'openapi.yml#/components/responses/UnauthorizedError'
+          "500":
+            $ref: 'openapi.yml#/components/responses/InternalServerError'

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -232,6 +232,9 @@ paths:
   '/authn-oidc/{service_id}/{account}/authenticate':
     $ref: 'authentication.yaml#/components/paths/OIDCAuthenticate'
 
+  '/authn-gcp/{account}/authenticate':
+    $ref: 'authentication.yaml#/components/paths/GCPAuthenticate'
+
 # ========== STATUS ===========
 
   '/whoami':


### PR DESCRIPTION
### What does this PR do?
Added GCP authenticate endpoint to spec file. In place of standing up an external GCP authenticator I have made a unit test to confirm that the client makes an appropriate call to the server.

### What ticket does this PR close?
Resolves #61

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
