### PR TITLE
Fixed python integration test array equality check

### DIFF
--- a/test/python/test_roles_api.py
+++ b/test/python/test_roles_api.py
@@ -801,7 +801,12 @@ class TestRolesApi(api_config.ConfiguredTest):
         ]
 
         self.assertEqual(status, 200)
-        self.assertEqual(details, target_details)
+        for i in target_details:
+            # This will throw an error causing the test to fail if
+            # i is not present in details
+            details.remove(i)
+
+        self.assertEqual(len(details), 0)
 
     def test_parameter_combos_c(self):
         """Test Conjur's response to being given both `members` and `memberships`
@@ -817,17 +822,16 @@ class TestRolesApi(api_config.ConfiguredTest):
             members=''
         )
 
-        target_details = [
-            {
+        target_details = {
                 'admin_option': False,
                 'ownership': False,
                 'role': self.USER_GROUP_ID,
                 'member': self.BOB_ID
             }
-        ]
 
         self.assertEqual(status, 200)
-        self.assertEqual(details, target_details)
+        self.assertEqual(len(details), 1)
+        self.assertEqual(details[0], target_details)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Cannot use `assertEqual` on arrays as it checks for indexed equality (elements at each index are the same). What we really wanted was to check that each element was in the array.

### What does this PR do?
Fixes test which would fail occasionally. 

### What ticket does this PR close?
Resolves #133

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
