### PR TITLE
Removed use of realpath in generate_client script

### DIFF
--- a/bin/api_test
+++ b/bin/api_test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source bin/util
 
 endpoint_flag=""

--- a/bin/bundle_spec
+++ b/bin/bundle_spec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker run --rm \
     -v ${PWD}:/code \

--- a/bin/cli
+++ b/bin/cli
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./bin/get_conjur_admin_key
 

--- a/bin/generate_client
+++ b/bin/generate_client
@@ -17,7 +17,7 @@ GENERATOR_IMAGE="openapitools/openapi-generator-cli:$generator_version"
 
 client_lang="python"
 make_client_dir=1
-output_volume="out/"
+output_volume="./out/"
 output_dir='/out'
 
 while test $# -gt 0
@@ -46,7 +46,10 @@ do
     esac
 done
 
-output_volume="$(realpath $output_volume)"
+if [ ! -e "$output_volume" ]; then
+    mkdir -p "$output_volume"
+fi
+output_volume="$(pushd $output_volume > /dev/null && echo ${PWD} && popd > /dev/null)"
 
 if [ $make_client_dir -eq 1 ]; then
     output_dir="$output_dir/$client_lang"

--- a/bin/get_conjur_admin_key
+++ b/bin/get_conjur_admin_key
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 admin_api_key=$(docker-compose exec -T conjur conjurctl role retrieve-key dev:user:admin | tr -d '\r')
 export CONJUR_AUTHN_API_KEY=$admin_api_key

--- a/bin/integration_tests
+++ b/bin/integration_tests
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 source bin/util
 

--- a/bin/lint_spec
+++ b/bin/lint_spec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./bin/bundle_spec
 

--- a/bin/lint_tests
+++ b/bin/lint_tests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Linting Python integration tests:"
 docker run --rm \

--- a/bin/start
+++ b/bin/start
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 # Start Conjur docker-compose environment
 bin/start_conjur

--- a/bin/start_conjur
+++ b/bin/start_conjur
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 cleanup() {
   echo "Cleaning up..."

--- a/bin/stop
+++ b/bin/stop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # deconstruct docker-compose env
 echo "Stop and remove docker-compose environment"

--- a/bin/util
+++ b/bin/util
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function get_banner(){
   for word in $@


### PR DESCRIPTION
Some OS' wont have `realpath` installed by default so we cannot rely on it in scripts

### What does this PR do?
Updated the script not to rely on `realpath`

### What ticket does this PR close?
Resolves #136

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
