### PR TITLE
Add K8s Inject Cert Endpoint

### DIFF
--- a/.github/workflows/k8s_inject.yml
+++ b/.github/workflows/k8s_inject.yml
@@ -1,0 +1,37 @@
+name: K8s Inject Test
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, edited]
+    paths:
+    - 'test/python/k8s/**'
+    - 'spec/authentication.yaml'
+
+  schedule:
+    - cron: '0 17 * * *'
+
+jobs:
+  run-k8s-inject-test-script:
+    name: Run K8s Inject Test Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+
+      - name: Install KinD
+        run: |
+          curl -fsSL -o kind https://kind.sigs.k8s.io/dl/v0.10.0/kind-linux-amd64
+          chmod 700 kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Install Kubernetes CLI
+        run: |
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+      - name: Run Test Scripts
+        run: ./test/python/k8s/start

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ coverage.xml
 
 test-python.csr
 test-python.key
+
+test/python/k8s/policy/generated/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nose2>=0.9.2
 nose2[coverage_plugin]>=0.6.5
 requests
+pyopenssl

--- a/test/python/k8s/Dockerfile
+++ b/test/python/k8s/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:latest
+ARG namespace
+MAINTAINER CyberArk
+
+ENV INSTALL_DIR=/opt/conjur-openapi-spec
+
+RUN apt-get update && \
+    apt-get install -y bash \
+                       binutils \
+                       build-essential \
+                       git \
+                       jq \
+                       python3 \
+                       python3-dev \
+                       python3-pip
+
+RUN mkdir -p $INSTALL_DIR
+WORKDIR $INSTALL_DIR
+
+COPY ./requirements.txt $INSTALL_DIR/
+RUN pip3 install -r requirements.txt
+
+COPY . $INSTALL_DIR
+
+RUN pip3 install -e out/python/
+
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
+CMD [ "sleep 9999" ]

--- a/test/python/k8s/deploy_test
+++ b/test/python/k8s/deploy_test
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+
+set -e
+. test/python/k8s/utils
+
+generate_policy() {
+    # generate Conjur policies from templates
+    # defines authn-k8s endpoint and identies that can authenticate to it
+    announce "Generating Policy"
+    pushd test/python/k8s/policy
+        mkdir -p ./generated
+
+        sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/cluster-authn-svc-def.template.yml > ./generated/$TEST_APP_NAMESPACE.cluster-authn-svc.yml
+
+        sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/project-authn-def.template.yml |
+            sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE#g" > ./generated/$TEST_APP_NAMESPACE.project-authn.yml
+
+        sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" ./templates/app-identity-def.template.yml |
+            sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE#g" > ./generated/$TEST_APP_NAMESPACE.app-identity.yml
+    popd
+}
+
+init_cli() {
+    # intialize Conjur CLI pod
+    # pull image, push to local registry, and build CLI pod
+    set_namespace $CONJUR_NAMESPACE
+    conjur_cli_pod=$(get_conjur_cli_pod_name)
+    if [ -z "$conjur_cli_pod" ]; then
+
+        announce "Pulling and Pushing Conjur CLI Image"
+
+        cli_app_image="${DOCKER_REG_URL}/conjur-cli:$CONJUR_NAMESPACE"
+        docker pull cyberark/conjur-cli:5
+        docker tag cyberark/conjur-cli:5 $cli_app_image
+        docker push $cli_app_image
+
+        announce "Deploying Conjur CLI Pod"
+
+        IMAGE_PULL_POLICY='Always'
+
+        sed -e "s#{{ CONJUR_SERVICE_ACCOUNT }}#$SERVICE_ACCOUNT#g" ./test/python/k8s/kubernetes/conjur-cli.yml |
+            sed -e "s#{{ DOCKER_IMAGE }}#$cli_app_image#g" |
+            sed -e "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
+            kubectl create -f -
+
+        conjur_cli_pod=$(get_conjur_cli_pod_name)
+        wait_for_it 300 "kubectl get pod $conjur_cli_pod -o jsonpath='{.status.phase}'| grep -q Running"
+    fi
+
+    announce "Ensure that Conjur CLI pod is initialized"
+
+    conjur_url="https://conjur-oss.$CONJUR_NAMESPACE.svc.cluster.local"
+    kubectl exec $conjur_cli_pod -- bash -c "yes yes | conjur init -a $CONJUR_ACCOUNT -u $conjur_url"
+    kubectl exec $conjur_cli_pod -- conjur authn login -u admin -p $CONJUR_ADMIN_API_KEY
+}
+
+load_policy() {
+    # load Conjur policies generated from templates
+    announce "Loading Conjur Policy"
+
+    kubectl exec $conjur_cli_pod -- rm -rf /policy
+    kubectl cp ./test/python/k8s/policy $conjur_cli_pod:/policy
+
+    kubectl exec $conjur_cli_pod -- \
+        bash -c "
+        conjur_appliance_url=https://conjur-oss.$CONJUR_NAMESPACE.svc.cluster.local}
+            CONJUR_ACCOUNT=${CONJUR_ACCOUNT} \
+            CONJUR_ADMIN_PASSWORD=${CONJUR_ADMIN_API_KEY} \
+            TEST_APP_NAMESPACE_NAME=${TEST_APP_NAMESPACE} \
+            /policy/load_policies.sh
+        "
+
+    kubectl exec $conjur_cli_pod -- rm -rf ./policy
+
+    echo "Conjur Policy Loaded"
+}
+
+configure_conjur_ca() {
+    announce "Initializing Conjur certificate authority"
+
+    set_namespace $CONJUR_NAMESPACE
+
+    conjur_master="$(kubectl get pods --selector "app=conjur-oss" --no-headers | awk '{ print $1 }')"
+    kubectl exec $conjur_master -c conjur-oss -- bash -c "
+        CONJUR_ACCOUNT=$CONJUR_ACCOUNT
+        rake authn_k8s:ca_init['conjur/authn-k8s/$AUTHENTICATOR_ID']
+    "
+
+    echo "Certificate authority initialized"
+}
+
+setup_test_app() {
+    # Create test namespace
+    announce "Creating Test App Namespace"
+
+    set_namespace default
+
+    if has_namespace "$TEST_APP_NAMESPACE"; then
+        echo "Namespace '$TEST_APP_NAMESPACE' exists, not going to create it."
+    else
+        echo "Creating '$TEST_APP_NAMESPACE' namespace."
+        kubectl create namespace $TEST_APP_NAMESPACE
+    fi
+    set_namespace $TEST_APP_NAMESPACE
+
+    # create rolebinding
+    kubectl delete --ignore-not-found rolebinding test-app-conjur-authenticator-role-binding-$CONJUR_NAMESPACE
+    conjur_authn_cluster_role="$HELM_RELEASE-conjur-authenticator"
+
+    echo $SERVICE_ACCOUNT
+
+    sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE#g" ./test/python/k8s/kubernetes/test-app-conjur-authenticator-role-binding.yml |
+        sed "s#{{ CONJUR_NAMESPACE_NAME }}#$CONJUR_NAMESPACE#g" |
+        sed "s#{{ CONJUR_AUTHN_CLUSTER_ROLE }}#$conjur_authn_cluster_role#g" |
+        sed "s#{{ CONJUR_SERVICE_ACCOUNT }}#$SERVICE_ACCOUNT#g" |
+        kubectl create -f -
+
+    # Store Conjur certificate in test namespace
+    announce "Storing Conjur cert for test app configuration."
+
+    set_namespace $CONJUR_NAMESPACE
+
+    echo "Retrieving Conjur certificate."
+    master_pod_name="$(kubectl get pods --selector "app=conjur-oss" --no-headers | awk '{ print $1 }')"
+    ssl_cert=$(kubectl exec -c "conjur-oss-nginx" $master_pod_name -- cat /opt/conjur/etc/ssl/cert/tls.crt)
+
+    set_namespace $TEST_APP_NAMESPACE
+
+    echo "Storing non-secret Conjur cert as test app configuration data"
+    kubectl delete --ignore-not-found=true configmap $TEST_APP_NAMESPACE
+    kubectl create configmap $TEST_APP_NAMESPACE --from-file=ssl-certificate=<(echo "$ssl_cert")
+
+    echo "Conjur certificate stored."
+
+    # Build and push test containers
+    announce "Building and pushing test app images"
+
+    echo "Building test app image"
+    docker build \
+        --build-arg namespace=$TEST_APP_NAMESPACE \
+        --tag test-app:$CONJUR_NAMESPACE \
+        --file test/python/k8s/Dockerfile .
+
+    test_app_image="${DOCKER_REG_URL}/test-app:$CONJUR_NAMESPACE"
+    docker tag test-app:$CONJUR_NAMESPACE $test_app_image
+    docker push $test_app_image
+}
+
+deploy_test_app() {
+    announce "Deploying Test App Into $TEST_APP_NAMESPACE Namespace"
+
+    set_namespace $TEST_APP_NAMESPACE
+
+    urlencoded_authn_id=$(urlencode $AUTHENTICATOR_ID)
+    authenticator_client_image="cyberark/conjur-authn-k8s-client"
+    conjur_appliance_url="https://conjur-oss.$CONJUR_NAMESPACE.svc.cluster.local"
+    conjur_authenticator_url="$conjur_appliance_url/authn-k8s/$urlencoded_authn_id"
+    conjur_auth_login_prefix=host/conjur/authn-k8s/$AUTHENTICATOR_ID/apps
+    IMAGE_PULL_POLICY='Always'
+
+    kubectl delete --ignore-not-found \
+        deployment/test-app \
+        service/test-app \
+        serviceaccount/test-app
+
+    sleep 5
+
+    conjur_pod="$(kubectl get pods --selector "app=conjur-oss" --no-headers -n $CONJUR_NAMESPACE | awk '{ print $1 }')"
+    conjur_ip="$(kubectl describe pod -n $CONJUR_NAMESPACE $conjur_pod | grep "IP:" | awk '{ print $2 }' | head -1)"
+
+    sed "s#{{ TEST_APP_DOCKER_IMAGE }}#$test_app_image#g" ./test/python/k8s/kubernetes/test-app.yml |
+        sed "s#{{ AUTHENTICATOR_CLIENT_IMAGE }}#$authenticator_client_image#g" |
+        sed "s#{{ IMAGE_PULL_POLICY }}#$IMAGE_PULL_POLICY#g" |
+        sed "s#{{ CONJUR_ACCOUNT }}#$CONJUR_ACCOUNT#g" |
+        sed "s#{{ CONJUR_IP }}#$conjur_ip#g" |
+        sed "s#{{ CONJUR_AUTHN_API_KEY }}#$CONJUR_ADMIN_API_KEY#g" |
+        sed "s#{{ CONJUR_AUTHN_LOGIN_PREFIX }}#$conjur_auth_login_prefix#g" |
+        sed "s#{{ CONJUR_APPLIANCE_URL }}#$conjur_appliance_url#g" |
+        sed "s#{{ CONJUR_AUTHN_URL }}#$conjur_authenticator_url#g" |
+        sed "s#{{ TEST_APP_NAMESPACE_NAME }}#$TEST_APP_NAMESPACE#g" |
+        sed "s#{{ AUTHENTICATOR_ID }}#$AUTHENTICATOR_ID#g" |
+        sed "s#{{ CONFIG_MAP_NAME }}#$TEST_APP_NAMESPACE#g" |
+        sed "s#{{ SERVICE_TYPE }}#NodePort#g" |
+        kubectl create -f -
+
+    echo "Test app deployed."
+}
+
+generate_policy
+init_cli
+load_policy
+configure_conjur_ca
+setup_test_app
+deploy_test_app
+
+echo "Waiting for test-app pod to be ready"
+while [[ "$(kubectl get pods -n $TEST_APP_NAMESPACE -o jsonpath={.items[*].status.containerStatuses[0].ready})" != "true" ]]; do
+    echo "."
+    sleep 2
+done
+echo "Pod ready"
+
+pod_name="$(kubectl get pods | grep 'test-app' | grep -v 'deploy' | awk '{ print $1 }')"
+bash_cmd="printf \"$conjur_ip conjur-oss\n\" >> /etc/hosts"
+kubectl exec $pod_name -c test-app \
+    -- bash -c "$bash_cmd"

--- a/test/python/k8s/kubernetes/conjur-cli.yml
+++ b/test/python/k8s/kubernetes/conjur-cli.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: conjur-cli
+  labels:
+    app: conjur-cli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: conjur-cli
+  template:
+    metadata:
+      name: conjur-cli
+      labels:
+        app: conjur-cli
+    spec:
+      serviceAccountName: {{ CONJUR_SERVICE_ACCOUNT }}
+      containers:
+      - name: conjur-cli
+        image: {{ DOCKER_IMAGE }}
+        imagePullPolicy: {{ IMAGE_PULL_POLICY }}
+        command: ["sleep"]
+        args: ["infinity"]
+      imagePullSecrets:
+        - name: dockerpullsecret

--- a/test/python/k8s/kubernetes/test-app-conjur-authenticator-role-binding.yml
+++ b/test/python/k8s/kubernetes/test-app-conjur-authenticator-role-binding.yml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-app-conjur-authenticator-role-binding-{{ CONJUR_NAMESPACE_NAME }}
+  namespace: {{ TEST_APP_NAMESPACE_NAME }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ CONJUR_SERVICE_ACCOUNT }}
+    namespace: {{ CONJUR_NAMESPACE_NAME }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ CONJUR_AUTHN_CLUSTER_ROLE }}

--- a/test/python/k8s/kubernetes/test-app.yml
+++ b/test/python/k8s/kubernetes/test-app.yml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app
+  labels:
+    app: test-app
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: test-app
+  type: {{ SERVICE_TYPE }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      serviceAccountName: test-app
+      containers:
+      - image: {{ TEST_APP_DOCKER_IMAGE }}
+        imagePullPolicy: {{ IMAGE_PULL_POLICY }}
+        name: test-app
+        ports:
+        - name: http
+          containerPort: 8080
+        env:
+          - name: CONJUR_APPLIANCE_URL
+            value: "{{ CONJUR_APPLIANCE_URL }}"
+          - name: CONJUR_ACCOUNT
+            value: {{ CONJUR_ACCOUNT }}
+          - name: CONJUR_AUTHN_API_KEY
+            value: {{ CONJUR_AUTHN_API_KEY }}
+          - name: CONJUR_IP
+            value: {{ CONJUR_IP }}
+          - name: CONJUR_AUTHN_TOKEN_FILE
+            value: /run/conjur/access-token
+          - name: CONJUR_SSL_CERTIFICATE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ CONFIG_MAP_NAME }}
+                key: ssl-certificate
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: TEST_APP_NAMESPACE
+            value: {{ TEST_APP_NAMESPACE_NAME }}
+        volumeMounts:
+          - mountPath: /run/conjur
+            name: conjur-access-token
+            readOnly: true
+      - image: {{ AUTHENTICATOR_CLIENT_IMAGE }}
+        imagePullPolicy: Always
+        name: authenticator
+        env:
+          - name: CONTAINER_MODE
+            value: sidecar
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: CONJUR_AUTHN_URL
+            value: "{{ CONJUR_AUTHN_URL }}"
+          - name: CONJUR_ACCOUNT
+            value: {{ CONJUR_ACCOUNT }}
+          - name: CONJUR_AUTHN_LOGIN
+            value: "{{ CONJUR_AUTHN_LOGIN_PREFIX }}/test-app"
+          - name: CONJUR_AUTHN_API_KEY
+            value: {{ CONJUR_AUTHN_API_KEY }}
+          - name: CONJUR_SSL_CERTIFICATE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ CONFIG_MAP_NAME }}
+                key: ssl-certificate
+        volumeMounts:
+          - mountPath: /run/conjur
+            name: conjur-access-token
+      imagePullSecrets:
+        - name: dockerpullsecret
+      volumes:
+        - name: conjur-access-token
+          emptyDir:
+            medium: Memory

--- a/test/python/k8s/policy/load_policies.sh
+++ b/test/python/k8s/policy/load_policies.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [ "$CONJUR_APPLIANCE_URL" != "" ]; then
+  conjur init -u $CONJUR_APPLIANCE_URL -a $CONJUR_ACCOUNT
+fi
+
+# check for unset vars after checking for appliance url
+set -u
+
+conjur authn login -u admin -p $CONJUR_ADMIN_PASSWORD
+
+readonly POLICY_DIR="/policy"
+
+# NOTE: generated files are prefixed with the test app namespace to allow for parallel CI
+readonly POLICY_FILES=(
+  "$POLICY_DIR/generated/$TEST_APP_NAMESPACE_NAME.project-authn.yml"
+  "$POLICY_DIR/generated/$TEST_APP_NAMESPACE_NAME.cluster-authn-svc.yml"
+  "$POLICY_DIR/generated/$TEST_APP_NAMESPACE_NAME.app-identity.yml"
+)
+
+for policy_file in "${POLICY_FILES[@]}"; do
+  echo "Loading policy $policy_file..."
+  conjur policy load root $policy_file
+done
+
+conjur authn logout

--- a/test/python/k8s/policy/templates/app-identity-def.template.yml
+++ b/test/python/k8s/policy/templates/app-identity-def.template.yml
@@ -1,0 +1,13 @@
+---
+- !policy
+  id: test-app
+  annotations:
+    description: This policy connects authn identities to an application identity. It defines a layer named for an application that contains the whitelisted identities that can authenticate to the authn-k8s endpoint. Any permissions granted to the application layer will be inherited by the whitelisted authn identities, thereby granting access to the authenticated identity.
+  body:
+  - !layer
+
+ # add authn identities to application layer so authn roles inherit app's permissions
+  - !grant
+    role: !layer
+    members:
+    - !layer /conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps

--- a/test/python/k8s/policy/templates/cluster-authn-svc-def.template.yml
+++ b/test/python/k8s/policy/templates/cluster-authn-svc-def.template.yml
@@ -1,0 +1,35 @@
+---
+# This policy defines an authn-k8s endpoint, CA creds and a layer for whitelisted identities permitted to authenticate to it
+- !policy
+  id: conjur/authn-k8s/{{ AUTHENTICATOR_ID }}
+  annotations:
+    description: Namespace defs for the Conjur cluster in dev
+  body:
+  - !webservice
+    annotations:
+      description: authn service for cluster
+
+  - !policy
+    id: ca
+    body:
+    - !variable
+      id: cert
+      annotations:
+        description: CA cert for Kubernetes Pods.
+    - !variable
+      id: key
+      annotations:
+        description: CA key for Kubernetes Pods.
+
+  # define layer of whitelisted authn ids permitted to call authn service
+  - !layer users
+
+  - !permit
+    resource: !webservice
+    privilege: [ read, authenticate ]
+    role: !layer users
+
+- !grant
+  role: !layer conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/users
+  members:
+    - !layer conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps

--- a/test/python/k8s/policy/templates/project-authn-def.template.yml
+++ b/test/python/k8s/policy/templates/project-authn-def.template.yml
@@ -1,0 +1,43 @@
+---
+# This policy defines a layer of whitelisted identities permitted to authenticate to the authn-k8s endpoint.
+- !policy
+  id: conjur/authn-k8s/{{ AUTHENTICATOR_ID }}/apps
+  annotations:
+    description: Identities permitted to authenticate
+  body:
+  - !layer
+    annotations:
+      description: Layer of authenticator identities permitted to call authn svc
+  - &hosts
+    # Annotation-based authentication (host ID is an application name, and
+    # permitted application identities are listed as annotations)
+    - !host
+      id: test-app
+      annotations:
+        authn-k8s/namespace: {{ TEST_APP_NAMESPACE_NAME }}
+        authn-k8s/service-account: test-app
+        authn-k8s/deployment: test-app
+        authn-k8s/authentication-container-name: authenticator
+        kubernetes: "true"
+
+    # Host-ID based authentication (application identity in the host itself)
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/*/*
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+        openshift: "false"
+
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/service_account/test-app
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+        kubernetes: "true"
+    - !host
+      id: {{ TEST_APP_NAMESPACE_NAME }}/deployment/test-app
+      annotations:
+        kubernetes/authentication-container-name: authenticator
+        kubernetes: "true"
+
+  - !grant
+    role: !layer
+    members: *hosts

--- a/test/python/k8s/setup_env
+++ b/test/python/k8s/setup_env
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -e
+. test/python/k8s/utils
+
+announce "Setting up test environment"
+# Create KinD cluster and local Docker registry
+# Check if KinD cluster has already been created
+if [ "$(kind get clusters | grep "^$KIND_CLUSTER_NAME$")" = "$KIND_CLUSTER_NAME" ]; then
+    echo "KinD cluster '$KIND_CLUSTER_NAME' already exists. Skipping cluster creation."
+    if [ "$(registry_container_is_running)" != "true" ]; then
+        echo "KinD cluster '$KIND_CLUSTER_NAME' does not have an internal Docker registry running"
+        echo "and 'USE_DOCKER_LOCAL_REGISTRY' is set to 'true'. To use an"
+        echo "internal Docker registry, please delete the KinD cluster:"
+        echo "    kind delete cluster --name $KIND_CLUSTER_NAME"
+        echo "and restart the demo scripts to create a new KinD cluster."
+        exit 1
+    fi
+else
+    announce "Creating KinD Cluster with local registry"
+
+    reg_name="$DOCKER_REG_NAME"
+    reg_port="$DOCKER_REG_PORT"
+
+    # create registry container unless it already exists
+    if [ "$(registry_container_is_running)" != "true" ]; then
+        echo "Creating a registry container"
+        # Create a Docker network named 'kind' if not already created
+        docker network inspect kind >/dev/null 2>&1 || \
+            docker network create kind
+        docker run \
+            -d --restart=always -p "${reg_port}:${reg_port}" --name "${reg_name}" --net=kind \
+            registry:2
+    fi
+    reg_ip="$(docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "${reg_name}")"
+
+    # create a cluster with the local registry enabled in containerd
+    cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_ip}:${reg_port}"]
+EOF
+
+fi
+
+# Helm install Conjur
+if has_namespace "$CONJUR_NAMESPACE"; then
+    echo "Namespace '$CONJUR_NAMESPACE' exists, not going to create it."
+else
+    kubectl create ns "$CONJUR_NAMESPACE"
+fi
+
+if [ "$(helm list -q -n $CONJUR_NAMESPACE | grep "^$HELM_RELEASE$")" = "$HELM_RELEASE" ]; then
+    echo "Helm upgrading existing Conjur cluster. Waiting for upgrade to complete."
+    helm upgrade \
+        -n "$CONJUR_NAMESPACE" \
+        --set account.name="$CONJUR_ACCOUNT" \
+        --set account.create="true" \
+        --set authenticators="authn\,authn-k8s/$AUTHENTICATOR_ID" \
+        --set logLevel="$CONJUR_LOG_LEVEL" \
+        --set service.external.enabled="false" \
+        --reuse-values \
+        --wait \
+        --timeout 300s \
+        "$HELM_RELEASE" \
+        "https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v$VERSION/conjur-oss-$VERSION.tgz"
+else
+    echo "Helm install a Conjur cluster. Waiting for install to complete."
+    data_key="$(docker run --rm cyberark/conjur data-key generate)"
+    helm install \
+        -n "$CONJUR_NAMESPACE" \
+        --set dataKey="$data_key" \
+        --set account.name="$CONJUR_ACCOUNT" \
+        --set account.create="true" \
+        --set authenticators="authn\,authn-k8s/$AUTHENTICATOR_ID" \
+        --set logLevel="$CONJUR_LOG_LEVEL" \
+        --set service.external.enabled="false" \
+        --wait \
+        --timeout 300s \
+        "$HELM_RELEASE" \
+        "https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v$VERSION/conjur-oss-$VERSION.tgz"
+fi
+
+# Ensure authn-k8s enabled
+authenticators="$(kubectl get secret \
+                  -n $CONJUR_NAMESPACE \
+                  $HELM_RELEASE-conjur-authenticators \
+                  --template={{.data.key}} | base64 -d)"
+if grep -q "$authenticators" <<< "$AUTHENTICATOR_ID"; then
+  echo "Enabling authenticator ID $AUTHENTICATOR_ID for authn-k8s"
+  helm upgrade \
+       -n "$CONJUR_NAMESPACE" \
+       --reuse-values \
+       --set authenticators="authn\,authn-k8s/$AUTHENTICATOR_ID" \
+       --set logLevel="$CONJUR_LOG_LEVEL" \
+       --wait \
+       --timeout 300s \
+       "$HELM_RELEASE" \
+       "https://github.com/cyberark/conjur-oss-helm-chart/releases/download/v$VERSION/conjur-oss-$VERSION.tgz"
+
+else
+  echo "Authenticator ID $AUTHENTICATOR_ID is already enabled for authn-k8s"
+fi
+
+wait_for_conjur_ready

--- a/test/python/k8s/start
+++ b/test/python/k8s/start
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -e
+. test/python/k8s/utils
+trap 'cleanup' ERR
+
+cleanup() {
+    echo "Cleaning up..."
+    kubectl delete namespace $CONJUR_NAMESPACE $TEST_APP_NAMESPACE
+}
+
+print_help(){
+  echo -e "Usage: ./test/python/k8s/start[--no-regen-client]"
+  echo
+  echo -e "\tThis script tests the functionality of Conjur's API endpoint to inject"
+  echo -e "\ta client certificate into a specified Kubernetes pod using Python client"
+  echo -e "\tgenerated from the OpenAPI spec. The script sets up a Conjur K8s deployment"
+  echo -e "\tand a test app."
+  echo
+  echo -e "\tThe --no-regen-client flag will prevent the client from re-generating before tests run"
+}
+
+no_regen_client=0
+
+while test $# -gt 0
+do
+  param=$1
+  shift
+  case "$param" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    --no-regen-client)
+      no_regen_client=1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# Set environment variables
+export KIND_CLUSTER_NAME="kind"
+export HELM_RELEASE="conjur-oss"
+export CONJUR_NAMESPACE="conjur-oss"
+export CONJUR_ACCOUNT="dev"
+export CONJUR_LOG_LEVEL="info"
+export CONJUR_VERSION="1.11.0"
+export VERSION="2.0.3"
+
+export TEST_APP_NAMESPACE="app-test"
+export ANNOTATION_BASE_AUTHN="true"
+export AUTHENTICATOR_ID="my-authenticator-id"
+export SERVICE_ACCOUNT='conjur-oss'
+
+export DOCKER_REG_NAME="kind-registry"
+export DOCKER_REG_PORT="5000"
+export DOCKER_REG_URL="localhost:$DOCKER_REG_PORT"
+
+# check for required tools
+if ! command -v kind &> /dev/null; then
+    echo "kind binary not found. See https://kind.sigs.k8s.io/docs/quick-start/"
+    echo "for installation instructions."
+    exit 1
+fi
+
+min_kind_version="0.7.0"
+kind_version="$(kind version -q)"
+if ! meets_min_version $kind_version $min_kind_version; then
+    echo "kind version $kind_version is invalid. Version must be $min_kind_version or newer"
+    exit 1
+fi
+
+if ! command -v helm &> /dev/null; then
+    echo "helm binary not found. See https://helm.sh/docs/intro/install/"
+    echo "for installation instructions."
+    exit 1
+fi
+
+min_helm_version="3.1"
+helm_version="$(helm version --template {{.Version}} | sed 's/^v//')"
+if ! meets_min_version $helm_version $min_helm_version; then
+    echo "helm version $helm_version is invalid. Version must be $min_helm_version or newer"
+    exit 1
+fi
+
+if [ $no_regen_client -eq 0 ]; then
+    announce "Generating Python Client"
+    ./bin/generate_client python
+fi
+
+# Set up Conjur K8s cluster and local Docker Registry
+./test/python/k8s/setup_env
+
+conjur_master_pod="$(kubectl get pods \
+    -n "$CONJUR_NAMESPACE" \
+    -l "app=conjur-oss,release=$HELM_RELEASE" \
+    -o jsonpath="{.items[0].metadata.name}")"
+
+export CONJUR_ADMIN_API_KEY="$(kubectl exec \
+    -n "$CONJUR_NAMESPACE" \
+    "$conjur_master_pod" \
+    --container=conjur-oss \
+    -- conjurctl role retrieve-key "$CONJUR_ACCOUNT":user:admin | tail -1)"
+
+# deploy test app
+./test/python/k8s/deploy_test
+
+# run endpoint tests
+announce "Running tests"
+pod_name="$(kubectl get pods | grep 'test-app' | grep -v 'deploy' | awk '{ print $1 }')"
+
+while [[ -z "$(kubectl exec $pod_name -c test-app -- cat /run/conjur/access-token 2>/dev/null)" ]]; do
+    echo "Waiting for Conjur access token in shared volume..."
+    sleep 2
+done
+
+kubectl exec $pod_name -c test-app \
+    -- nose2 --plugin nose2.plugins.junitxml --with-coverage --coverage-report xml -X -v -s test/python/k8s
+
+# remove test app deployments and namespaces
+announce "Destroying environment"
+cleanup

--- a/test/python/k8s/test_client_cert_inject.py
+++ b/test/python/k8s/test_client_cert_inject.py
@@ -1,0 +1,124 @@
+from __future__ import absolute_import
+
+import base64
+import os
+import pathlib
+import unittest
+
+import openapi_client
+
+from OpenSSL import crypto, SSL
+
+CERT_DIR = pathlib.Path('config/https')
+SSL_CERT_FILE = 'ca.crt'
+CONJUR_CERT_FILE = 'conjur.crt'
+CONJUR_KEY_FILE = 'conjur.key'
+
+def generateKey(type, bits):
+    """Generates a key using OpenSSL"""
+    key = crypto.PKey()
+    key.generate_key(type, bits)
+
+    return key
+
+def generateCSR(host_id, key):
+    """Generate a Certificate Signing Request"""
+    pod_name = os.environ['MY_POD_NAME']
+    namespace = os.environ['TEST_APP_NAMESPACE']
+    SANURI = f'spiffe://cluster.local/namespace/{namespace}/podname/{pod_name}'
+
+
+    req = crypto.X509Req()
+    req.get_subject().CN = host_id
+    req.set_pubkey(key)
+
+    formatted_SAN = f'URI:{SANURI}'
+    req.add_extensions([
+        crypto.X509Extension(
+            'subjectAltName'.encode('ascii'), False, formatted_SAN.encode('ascii')
+        )
+    ])
+
+    req.sign(key, "sha1")
+
+    return crypto.dump_certificate_request(crypto.FILETYPE_PEM, req)
+
+class TestClientCertInject(unittest.TestCase):
+
+    def setUp(self):
+        with open(os.environ['CONJUR_AUTHN_TOKEN_FILE'], 'r') as content:
+            encoded_token = base64.b64encode(content.read().replace('\r', '').encode()).decode('utf-8')
+
+        config = openapi_client.Configuration(
+                host='https://conjur-oss:9443'
+            )
+
+        with open(CERT_DIR.joinpath(SSL_CERT_FILE), 'w') as content:
+            content.write(os.environ['CONJUR_SSL_CERTIFICATE'])
+
+        config.ssl_ca_cert = CERT_DIR.joinpath(SSL_CERT_FILE)
+        config.username = 'admin'
+        config.api_key = {'Authorization': 'Token token="{}"'.format(encoded_token)}
+
+        self.client = openapi_client.ApiClient(config)
+        self.api = openapi_client.api.authn_api.AuthnApi(self.client)
+
+        key = generateKey(crypto.TYPE_RSA, 2048)
+        self.csr = generateCSR('app-test/*/*', key)
+
+    def tearDown(self):
+        self.client.close()
+
+    def test_inject_202(self):
+        """Test 202 status response when successfully requesting a client certificate injection
+        202 - successful request and injection
+        """
+        # optional prefix
+        # prefix = 'host/conjur/authn-k8s/my-authenticator-id/apps'
+        response, status, _ = self.api.k8s_inject_client_cert_with_http_info(
+            'my-authenticator-id',
+            body=self.csr
+        )
+
+        self.assertEqual(status, 202)
+        self.assertEqual(None, response)
+
+    def test_inject_400(self):
+        """Test 400 status response when successfully requesting a cert injection
+        400 - Bad Request caught by NGINX
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.k8s_inject_client_cert(
+                '\00',
+                body=self.csr
+            )
+
+        self.assertEqual(context.exception.status, 400)
+
+    def test_inject_401(self):
+        """Test 401 status response when requesting a cert injection
+        401 - unauthorized request. This happens from invalid Conjur auth token,
+        incorrect service ID, malformed CSR and others
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.k8s_inject_client_cert(
+                'wrong-service-id',
+                body=self.csr
+            )
+
+        self.assertEqual(context.exception.status, 401)
+
+    def test_inject_404(self):
+        """Test 404 status response when requesting a cert injection
+        404 - Resource not found, malformed service ID
+        """
+        with self.assertRaises(openapi_client.ApiException) as context:
+            self.api.k8s_inject_client_cert(
+                '00.00',
+                body=self.csr
+            )
+
+        self.assertEqual(context.exception.status, 404)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/k8s/utils
+++ b/test/python/k8s/utils
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+announce() {
+  echo "++++++++++++++++++++++++++++++++++++++++++++++++++++"
+  echo ""
+  echo "$@"
+  echo ""
+  echo "++++++++++++++++++++++++++++++++++++++++++++++++++++"
+}
+
+oldest_version() {
+  v1=$1
+  v2=$2
+
+  echo "$(printf '%s\n' "$v1" "$v2" | sort -V | head -n1)"
+}
+
+meets_min_version() {
+  actual_version=$1
+  min_version=$2
+
+  oldest="$(oldest_version $actual_version $min_version)"
+  if [ "$oldest" = "$min_version" ]; then
+    true
+  else
+    false
+  fi
+}
+
+has_namespace() {
+  if kubectl get namespace  "$1" > /dev/null; then
+    true
+  else
+    false
+  fi
+}
+
+set_namespace() {
+  if [[ $# != 1 ]]; then
+    printf "Error in %s/%s - expecting 1 arg.\n" $(pwd) $0
+    exit -1
+  fi
+
+  kubectl config set-context $(kubectl config current-context) --namespace="$1" > /dev/null
+}
+
+pods_ready() {
+  app_label=$1
+  $cli describe pod --selector "app=$app_label" | awk '/Ready/{if ($2 != "True") exit 1}'
+}
+
+external_ip() {
+  service=$1
+  echo "$(kubectl get svc $service -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+}
+
+registry_container_is_running() {
+    docker inspect -f '{{.State.Running}}' $DOCKER_REG_NAME 2>/dev/null
+}
+
+wait_for_conjur_ready() {
+  echo "Waiting for Conjur pod to be ready"
+  kubectl wait --for=condition=ready pod \
+                     -n $CONJUR_NAMESPACE \
+                     -l "app=conjur-oss,release=$HELM_RELEASE" \
+                     --timeout 300s
+  echo "Waiting for Postgres pod to be ready"
+  kubectl wait --for=condition=ready pod \
+                     -n $CONJUR_NAMESPACE \
+                     -l "app=conjur-oss,release=$HELM_RELEASE" \
+                     --timeout 300s
+}
+
+get_conjur_cli_pod_name() {
+  pod_list=$(kubectl get pods -n "$CONJUR_NAMESPACE" --selector app=conjur-cli --no-headers | awk '{ print $1 }')
+  echo $pod_list | awk '{print $1}'
+}
+
+wait_for_it() {
+  local timeout=$1
+  local spacer=2
+  shift
+
+  if ! [ $timeout = '-1' ]; then
+    local times_to_run=$((timeout / spacer))
+
+    echo "Waiting for '$@' up to $timeout s"
+    for i in $(seq $times_to_run); do
+      eval $@ > /dev/null && echo 'Success!' && return 0
+      echo -n .
+      sleep $spacer
+    done
+
+    # Last run evaluated. If this fails we return an error exit code to caller
+    eval $@
+  else
+    echo "Waiting for '$@' forever"
+
+    while ! eval $@ > /dev/null; do
+      echo -n .
+      sleep $spacer
+    done
+    echo 'Success!'
+  fi
+}
+
+urlencode() {
+  # urlencode <string>
+
+  # Run as a subshell so that we can indiscriminately set LC_COLLATE
+  (
+    LC_COLLATE=C
+
+    local length="${#1}"
+    for (( i = 0; i < length; i++ )); do
+      local c="${1:i:1}"
+      case $c in
+        [a-zA-Z0-9.~_-]) printf "$c" ;;
+        *) printf '%%%02X' "'$c" ;;
+      esac
+    done
+  )
+}


### PR DESCRIPTION
### What does this PR do?
My last PR added the `/authn-k8s/:service_id/inject_client_cert` endpoint to the OpenAPI spec.
This PR adds:
- an environment for testing this endpoint,
- test cases for each possible HTTP status response, 
- a stage in the project's Jenkins pipeline to run the tests,
- a GitHub Action to run the test daily, and when files pertaining to the endpoint are changed.

### What ticket does this PR close?
Resolves #3 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
