### PR TITLE
Add K8s Inject Cert endpoint to API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Google Cloud Provider authenticate endpoint now included in the spec file. Users can now authenticate with Conjur using GCP.
   [cyberark/conjur-openapi-spec#61](https://github.com/cyberark/conjur-openapi-spec/issues/61)
 - New options to `generate_client` script for greater control over generated output.
+- `/authn-k8s/:service_id/inject_client_cert` endpoint now included in the OpenAPI specification.
+  [cyberark/conjur-openapi-spec#3](https://github.com/cyberark/conjur-openapi-spec/issues/3)

--- a/spec/authentication.yaml
+++ b/spec/authentication.yaml
@@ -505,3 +505,46 @@ components:
             $ref: 'openapi.yml#/components/responses/UnauthorizedError'
           "500":
             $ref: 'openapi.yml#/components/responses/InternalServerError'
+
+    K8sInjectClientCert:
+      post:
+        tags:
+        - "authn"
+        summary: "Requests a client certificate injection into the desired K8s pod"
+        description: "This request sends a Certificate Signing Request to Conjur, which in uses the Kubernetes API to inject a certificate into the desired pod.
+
+        This endpoint requires a properly configured Conjur Certificate Authority service alongside a properly configured K8s authenticator."
+        operationId: "k8sInjectClientCert"
+        parameters:
+        - name: "service_id"
+          in: "path"
+          description: "The service id of the K8s authenticator"
+          required: true
+          schema:
+            type: string
+        - name: "Host-Id-Prefix"
+          in: header
+          description: "Host ID prefix"
+          schema:
+            type: string
+          example: "host/conjur/authn-k8s/my-authenticator-id/apps"
+        requestBody:
+          description: "The body of the request is a CSR"
+          required: true
+          content:
+            text/plain:
+              schema:
+                type: string
+
+        responses:
+          "202":
+            $ref: 'openapi.yml#/components/responses/Accepted'
+          "400":
+            $ref: 'openapi.yml#/components/responses/BadRequest'
+          "401":
+            $ref: 'openapi.yml#/components/responses/UnauthorizedError'
+          "404":
+            $ref: 'openapi.yml#/components/responses/ResourceNotFound'
+
+        security:
+          - conjurAuth: []

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -131,6 +131,8 @@ components:
         - `sales&marketing` -> `sales%26marketing`"
 
   responses:
+    Accepted:
+      description: "The injected certificate was accepted."
     AccessTokenGeneric:
       description: |
         This response schema is a generic string as opposed to the AccessToken component schema.
@@ -234,6 +236,9 @@ paths:
 
   '/authn-gcp/{account}/authenticate':
     $ref: 'authentication.yaml#/components/paths/GCPAuthenticate'
+
+  '/authn-k8s/{service_id}/inject_client_cert':
+    $ref: 'authentication.yaml#/components/paths/K8sInjectClientCert'
 
 # ========== STATUS ===========
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the `/authn-k8s/:service-id/inject-client-cert` endpoint to the OpenAPI spec. This
PR includes material blocking spec distribution. There is another open PR containing a test environment
and tests, but it is currently in progress.

### What ticket does this PR close?
Partially addresses #3 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
