### PR TITLE
Contract test now runs against conjur w/out nginx

### DIFF
--- a/bin/api_test
+++ b/bin/api_test
@@ -67,4 +67,4 @@ docker-compose run --rm --no-deps \
     --checks response_schema_conformance \
     -H \"Authorization: Basic \"$ENCODED_LOGIN\"\" \
     -H \"Authentication: Token token=\"$CONJUR_ADMIN_TOKEN\"\" \
-    --base-url https://conjur-https spec.yml"
+    --base-url http://conjur spec.yml"

--- a/spec/authentication.yaml
+++ b/spec/authentication.yaml
@@ -415,6 +415,8 @@ components:
             $ref: 'openapi.yml#/components/responses/UnauthorizedError'
           "404":
             $ref: 'openapi.yml#/components/responses/ResourceNotFound'
+          "422":
+            $ref: 'openapi.yml#/components/responses/UnprocessableEntity'
           "500":
             $ref: 'openapi.yml#/components/responses/InternalServerError'
 


### PR DESCRIPTION
### What does this PR do?
Sometimes Nginx will interfere with the raw return codes from Conjur itself so we need to run this test against bare Conjur to get all the intended return codes.

### What ticket does this PR close?
Resolves #151
Relates to cyberark/conjur#[Relevant conjur issue number]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
