### PR TITLE
Added secrets batch encoding feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-openapi-spec#3](https://github.com/cyberark/conjur-openapi-spec/issues/3)
 - Basic C#/.NET client tests and generation templates are now included in the project.
   [cyberark/conjur-openapi-spec#94](https://github.com/cyberark/conjur-openapi-spec/issues/94)
+- Optional Accept-Encoding header parameter now included in secrets batch endpoint.
+  [cyberark/conjur-openapi-spec#145](https://github.com/cyberark/conjur-openapi-spec/issues/145)

--- a/spec/secrets.yml
+++ b/spec/secrets.yml
@@ -150,6 +150,12 @@ components:
           required: true
           schema:
             $ref: '#/components/schemas/ResourceIDs'
+        - name: Accept-Encoding
+          in: header
+          description: "Set the encoding of the response object"
+          schema:
+            type: string
+            enum: [ base64 ]
 
         responses:
           "200":


### PR DESCRIPTION
### What does this PR do?
Added the new Accept-Encoding header parameter to the secrets batch endpoint and added a new test for the added functionality.

### What ticket does this PR close?
Resolves #145
Relates to PR cyberark/conjur#2065

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
