### PR TITLE
Update swagger ui info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-openapi-spec#129](https://github.com/cyberark/conjur-openapi-spec/issues/129)
 - Response schemas are now more fully defined and methods will now return pre-defined objects.
   [cyberark/conjur-openapi-spec#43](https://github.com/cyberark/conjur-openapi-spec/issues/43)
+- Renamed the `start_editor` script to `start_spec_ui` and updated it to open the bundled version of the spec.
+  [cyberark/conjur-openapi-spec#168](https://github.com/cyberark/conjur-openapi-spec/issues/168)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Contributing to this repository requires installation of some developer tools.
 
 ### Environment Setup
 
-Setup the development environment using the `start` script. The script starts a Swagger UI  
+Setup the development environment using the `start` script. The script starts a Swagger Editor  
 container, used to the edit the OpenAPI spec, and stands up a new instance of Conjur to test the  
 spec against.
 
@@ -60,14 +60,14 @@ spec against.
 $ ./bin/start
 ```
 
-To use the OpenAPI spec against a pre-existing Conjur server, start the Swagger UI editor with  
-the `start_editor` script.
+To use the OpenAPI spec against a pre-existing Conjur server, start the Swagger Editor editor with  
+the `start_spec_ui` script.
 
 ```shell
-$ ./bin/start_editor
+$ ./bin/start_spec_ui
 ```
 
-In each case, a browser window will be opened to the container running Swagger UI.  
+In each case, a browser window will be opened to the container running Swagger Editor.  
 Import the [`openapi.yml`](openapi.yml) into the UI to view/edit.
 
 The environment can be stopped and removed using the `stop` script.
@@ -129,24 +129,25 @@ To ensure your changes work as expected, you can run the [automated tests](#auto
 #### Utility scripts
 
 `bin/generate_client -l <language> [-o <output-directory>]`
-* Generates a client library for the desired `<language>`.  
+* Generates a client library for the desired `<language>`.
 * Running the script with no argument will generate a Python client by default.
 
 `bin/generate_kong_config`
 * Generates a declarative configuration used by Kong Gateway.
 
-`bin/start_editor`
-* Used to start a Swagger Editor container independent of a Conjur instance.  
+`bin/start_spec_ui`
+* Used to start a Swagger Editor container independent of a Conjur instance.
+* Runs the `bin/bundle_spec` script before starting and points the UI at the bundled spec.
 
 `bin/start`
-* Used to set up a new development environment.  
+* Used to set up a new development environment.
 * Stands up a new instance of Conjur, and starts a Swagger Editor container.
 
 `bin/start_conjur`
 * Used to start a new local Conjur instance based on the project's `docker-compose`.
 
 `bin/stop`
-* Used to deconstruct the development environmnet.  
+* Used to deconstruct the development environmnet.
 * Stops and removes the `docker-compose` environment and Swagger Editor.
 
 `bin/bundle_spec`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Need help with something that's not yet documented here? Please
 [open an issue](https://github.com/cyberark/conjur-openapi-spec/issues/new/choose) - we'd be happy
 to help you get started.
 
+### Swagger Editor
+
+The [Swagger Editor](https://swagger.io/tools/swagger-ui/) is a great tool for viewing and editing
+OpenAPI specifications, although we discourage editing directly in the UI because our spec
+is split over multiple files. In order to view the spec in Swagger run the
+`./bin/start_spec_ui` script, all of the standard spec files will be bundled together and
+an instance of the UI will be opened pointing at the bundled spec.
+
 ### Generating client libraries
 
 To generate a client library using the OpenAPI spec, use the provided script:

--- a/bin/start
+++ b/bin/start
@@ -3,5 +3,5 @@
 # Start Conjur docker-compose environment
 bin/start_conjur
 
-# Start Swagger UI
-bin/start_editor
+# Start Swagger Editor
+bin/start_spec_ui

--- a/bin/start_spec_ui
+++ b/bin/start_spec_ui
@@ -2,14 +2,19 @@
 
 set -euo pipefail
 
+source bin/util
+
 docker pull swaggerapi/swagger-editor
 
-echo "Removing old containers..."
+announce "Removing old containers..."
 docker stop swagger-editor || true
 docker rm swagger-editor || true
 
-echo "Starting Swagger editor on port 9090..."
-docker run -d -p 9090:8080 -v $(pwd):/tmp -e SWAGGER_FILE=/tmp/spec/openapi.yml --name swagger-editor swaggerapi/swagger-editor
+announce "Generating bundled spec file"
+./bin/bundle_spec
+
+announce "Starting Swagger editor on port 9090..."
+docker run -d -p 9090:8080 -v $(pwd):/tmp -e SWAGGER_FILE=/tmp/spec.yml --name swagger-editor swaggerapi/swagger-editor
 
 echo -n "Waiting for editor to start..."
 until [ "$(docker inspect -f {{.State.Running}} swagger-editor)"=="true" ]; do

--- a/bin/util
+++ b/bin/util
@@ -14,9 +14,9 @@ function get_banner(){
 
 function announce() {
   banner=$(get_banner $@)
-  echo $banner
-  echo "$@"
-  echo $banner
+  echo -e "\e[0;32m$banner"
+  echo -e "$@"
+  echo -e "$banner\e[m"
 }
 
 function ensure_client_is_generated(){


### PR DESCRIPTION
### What does this PR do?
Updated the `start_editor` script to bundle the spec, and point at the bundled spec. Also renamed the script to `start_swagger_ui` to reflect the fact that it is not really possible to use it as an editor in this project because the spec is split over multiple files.  The documentation has been updated to reflect these changes.

### What ticket does this PR close?
Resolves #168

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
