### PR TITLE
Added new request header for all endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-openapi-spec#145](https://github.com/cyberark/conjur-openapi-spec/issues/145)
 - Instructions and scripts for using the API spec with Postman included.
   [cyberark/conjur-openapi-spec#92](https://github.com/cyberark/conjur-openapi-spec/issues/92)
+- New header parameter allowing user to set reuquest IDs to all endpoints.
+  [cyberark/conjur-openapi-spec#175](https://github.com/cyberark/conjur-openapi-spec/issues/175)
 
 ### Fixed
 - Workaround for request body issue on revokeHostToken operation is now removed and tests have been updated.

--- a/spec/authentication.yml
+++ b/spec/authentication.yml
@@ -111,6 +111,8 @@ components:
 
   paths:
     DefaultLogin:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "authentication"
@@ -166,6 +168,8 @@ components:
 
 
     K8sInjectClientCert:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "authentication"
@@ -213,6 +217,8 @@ components:
             $ref: 'openapi.yml#/components/responses/ResourceNotFound'
 
     LDAPLogin:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "authentication"
@@ -264,6 +270,8 @@ components:
           - basicAuth: []
 
     DefaultAuthenticate:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "authentication"
@@ -338,6 +346,8 @@ components:
             $ref: 'openapi.yml#/components/responses/InternalServerError'
 
     AWSAuthenticate:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "authentication"
@@ -409,6 +419,8 @@ components:
             $ref: 'openapi.yml#/components/responses/InternalServerError'
 
     AzureAuthenticate:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "authentication"
@@ -480,6 +492,8 @@ components:
 
 
     GCPAuthenticate:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "authentication"
@@ -526,6 +540,8 @@ components:
 
 
     KubernetesAuthenticate:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "authentication"
@@ -592,6 +608,8 @@ components:
 
 
     LDAPAuthenticate:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "authentication"
@@ -668,6 +686,8 @@ components:
 
 
     OIDCAuthenticate:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "authentication"
@@ -710,6 +730,8 @@ components:
 
 
     ChangePassword:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       put:
         tags:
         - "authentication"
@@ -770,6 +792,8 @@ components:
           - basicAuth: []
 
     RotateApiKey:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       put:
         tags:
         - "authentication"
@@ -836,6 +860,8 @@ components:
             conjurAuth: []
 
     EnableAuthenticatorInstance:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       patch:
         tags:
         - "authentication"

--- a/spec/cert-auth.yml
+++ b/spec/cert-auth.yml
@@ -34,6 +34,8 @@ components:
 
   paths:
     Sign:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "certificate authority"

--- a/spec/host-factory.yml
+++ b/spec/host-factory.yml
@@ -151,6 +151,8 @@ components:
 
   paths:
     CreateHostToken:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "host factory"
@@ -190,6 +192,8 @@ components:
           - conjurAuth: []
 
     RevokeHostToken:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       delete:
         tags:
         - "host factory"
@@ -225,6 +229,8 @@ components:
           - conjurAuth: []
 
     CreateHost:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "host factory"

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -131,6 +131,18 @@ components:
       schema:
         type: string
 
+    RequestID:
+      name: X-Request-Id
+      in: header
+      required: false
+      description: |
+        Add an ID to the request being made so it can be tracked in Conjur.
+        If not provided the server will automatically generate one.
+      example: "test-id"
+      schema:
+        type: string
+        pattern: '^[a-zA-Z\d-]{1,255}$'
+
   responses:
     BadRequest:
       description: "The server cannot process the request due to malformed request syntax"

--- a/spec/policies.yml
+++ b/spec/policies.yml
@@ -41,6 +41,8 @@ components:
 
   paths:
     Policies:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       put:
         tags:
         - "policies"

--- a/spec/public-keys.yml
+++ b/spec/public-keys.yml
@@ -13,6 +13,8 @@ components:
 
   paths:
     PublicKeys:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "public keys"

--- a/spec/resources.yml
+++ b/spec/resources.yml
@@ -136,6 +136,8 @@ components:
 
   paths:
     ListResources:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "resources"
@@ -224,6 +226,8 @@ components:
           - conjurAuth: []
 
     ListResourcesOnAccount:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "resources"
@@ -310,6 +314,8 @@ components:
           - conjurAuth: []
 
     ListSimilarResourcesOnAccount:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "resources"
@@ -397,6 +403,8 @@ components:
           - conjurAuth: []
 
     SingleResource:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "resources"

--- a/spec/roles.yml
+++ b/spec/roles.yml
@@ -15,6 +15,8 @@ components:
 
   paths:
     Roles:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "roles"

--- a/spec/secrets.yml
+++ b/spec/secrets.yml
@@ -41,6 +41,8 @@ components:
 
   paths:
     Secret:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       post:
         tags:
         - "secrets"
@@ -157,6 +159,8 @@ components:
           - conjurAuth: []
 
     BatchSecrets:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "secrets"

--- a/spec/status.yml
+++ b/spec/status.yml
@@ -92,6 +92,8 @@ components:
 
   paths:
     WhoAmI:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "status"
@@ -112,6 +114,8 @@ components:
           - conjurAuth: []
 
     ServiceAuthenticatorStatus:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - 'status'
@@ -172,6 +176,8 @@ components:
           - conjurAuth: []
 
     AuthenticatorStatus:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - 'status'
@@ -213,6 +219,8 @@ components:
           - conjurAuth: []
 
     AuthenticatorsIndex:
+      parameters:
+        - $ref: 'openapi.yml#/components/parameters/RequestID'
       get:
         tags:
         - "status"

--- a/test/python/test_status_api.py
+++ b/test/python/test_status_api.py
@@ -194,5 +194,13 @@ class TestStatusApi(api_config.ConfiguredTest):
                 self.assertIsInstance(value, str)
                 self.assertNotEqual(value, '')
 
+    def test_set_request_id(self):
+        """Test case for setting the request ID on an endpoint"""
+        request_id = 'testing'
+        _, status, headers = self.api.get_authenticators_with_http_info(x_request_id=request_id)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers['X-Request-Id'], request_id)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What does this PR do?
This header applies to all endpoints, so the parameter is placed in the path instead of on each individual endpoint. This helps reduce some duplication, unfortunately it is not possible to apply one parameter globally.

### What ticket does this PR close?
Resolves #175 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
