### PR TITLE
Remove stale auth test

### DIFF
--- a/test/python/auth/test_authentication_external_api.py
+++ b/test/python/auth/test_authentication_external_api.py
@@ -118,20 +118,6 @@ class TestExternalAuthnApi(api_config.ConfiguredTest):
 
         self.assertEqual(context.exception.status, 401)
 
-# we should write one of these for each service; commenting out for now
-#    def test_get_access_token_service_404(self):
-#        """Test case for authenticate_service 404 response"""
-#        with self.assertRaises(conjur.exceptions.ApiException) as context:
-#            self.api.get_access_token_via_authenticator(
-#                'nonexist',
-#                'nonexist',
-#                self.account,
-#                'admin',
-#                body='badpass'
-#            )
-#
-#        self.assertEqual(context.exception.status, 404)
-
     def test_get_access_token_via_oidc_200(self):
         """Test case for oidc_authenticate 200 response"""
         api_config.setup_oidc_webservice()


### PR DESCRIPTION
### What does this PR do?
Commented test case requested adding test
cases for 404 responses on external auth
endpoints. This was a remnant from when
these endpoints were generalized.

### What ticket does this PR close?
Resolves #180 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
