### PR TITLE
Updated request body on secret creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Request body details for secret creation so all clients can properly set secrets. This changes
+  the MIME type of the request body to `application/octet-stream` in place of text plain,
+  allowing for proper binary secrets in clients (`format: binary` is broken in some clients).
+  [cyberark/conjur-openapi-spec#187](https://github.com/cyberark/conjur-openapi-spec/pull/187)
 
 ## [5.1.1] - 2021-04-28
 ### Added

--- a/spec/secrets.yml
+++ b/spec/secrets.yml
@@ -83,10 +83,9 @@ components:
           description: "Secret data"
           required: false
           content:
-            text/plain:
+            application/octet-stream:
               schema:
                 type: string
-                format: binary
 
         responses:
           "201":


### PR DESCRIPTION
### What does this PR do?
This allows the java client to properly set a secret in the generated client. Currently it is unable to properly handle the `format: binary` type for strings.

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
