### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Please see our [Community Repository](https://github.com/cyberark/community) and our [Contribution Guidelines](https://github.com/cyberark/community/blob/master/Conjur/CONTRIBUTING.md).
-They provide information regarding the process of contributing to Conjur OSS projects,
+They provide information regarding the process of contributing to Conjur Open Source projects,
 including issue reporting, pull request workflow and community guidelines.
 
 * [Prerequisites](#prerequisites)
@@ -47,7 +47,7 @@ Contributing to this repository requires installation of some developer tools.
 
 ### Conjur
 
-[Conjur OSS v1.9+](https://github.com/cyberark/conjur)
+[Conjur Open Source v1.9+](https://github.com/cyberark/conjur)
 
 ### OpenAPI
 
@@ -131,12 +131,12 @@ To ensure your changes work as expected, you can run the [automated tests](#auto
 
 `bin/test_api_contract [-e <endpoint>]`
 * Uses Schemathesis to generate test cases for API endpoints, which test the
-  conformance between Conjur OSS and the OpenAPI specification.
+  conformance between Conjur Open Source and the OpenAPI specification.
 * Runs containerized contract testing on all endpoints specified in [`openapi.yml`](openapi.yml)
 * Specifying an endpoint with the `-e|--endpoint` flag runs contract tests on that endpoint alone.
 
 `bin/test_integration`
-* Used to run the suite of integration tests against Conjur OSS or Enterprise.
+* Used to run the suite of integration tests against Conjur Open Source or Enterprise.
 * Stands up a new Conjur environment, generates a client
   library, and runs the integration test suite.
 * User must specify a client language to test with `-l`:
@@ -212,7 +212,7 @@ To ensure your changes work as expected, you can run the [automated tests](#auto
 #### Conjur Enterprise Developers
 
 The Enterprise only endpoints included in the specification all use a specific annotation to indicate that they
-are "enterprise only". When the OSS version of the spec is generated all of these objects will be removed.
+are "enterprise only". When the Open Source version of the spec is generated all of these objects will be removed.
 
 ```yaml
 someObject:
@@ -224,15 +224,13 @@ This marks `someObject` as an enterprise only feature.
 
 Note that because all `paths` have to be defined in the `openapi.yml#/paths` object it is
 acceptable to just put the annotation on the `openapi.yml#/paths/somePath` object and leave it
-off the referenced path definition. In this case when the OSS version of the spec is generated
+off the referenced path definition. In this case when the Open Source version of the spec is generated
 the path definition will have had its reference removed thereby not technically being
 included in the spec.
 
 Many of the scripts included in the `bin` directory have an optional `--enterprise` flag which
 tells the script to use the Enterprise version of the spec. To generate the Enterprise version
-of a client you would run `./bin/generate_client -l python --enterprise`. The only exception
-to this is the integration tests, which to run against an Enterprise container you must
-run the `./bin/test_dap` script.
+of a client you would run `./bin/generate_client -l python --enterprise`.
 
 ## Manual Testing
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/7bf3957dc33055b0de06/maintainability)](https://codeclimate.com/github/cyberark/conjur-openapi-spec/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/7bf3957dc33055b0de06/test_coverage)](https://codeclimate.com/github/cyberark/conjur-openapi-spec/test_coverage)
 
-This project contains the OpenAPI v3 specification for [Conjur OSS](https://www.conjur.org/).  
+This project contains the OpenAPI v3 specification for [Conjur Open Source](https://www.conjur.org/).  
 
 The Conjur OpenAPI specification provides a standardized, machine-readable version
 of the Conjur API that can be used to automatically generate API documentation, to
@@ -43,7 +43,7 @@ by CyberArk**. For more detailed information on our certification levels, see [o
 
 This project requires Docker and access to DockerHub.
 
-The OpenAPI Specification is compatible with [Conjur OSS v1.9+](https://github.com/cyberark/conjur).  
+The OpenAPI Specification is compatible with [Conjur Open Source v1.9+](https://github.com/cyberark/conjur).  
 Clients are generated using [OpenAPI Generator v4.3.1](https://github.com/OpenAPITools/openapi-generator/tree/v4.3.1).
 
 ### Use With Conjur Enterprise
@@ -77,7 +77,7 @@ source, you can run the following script to parse the custom `x-conjur-settings`
 generate an OpenAPI spec for the specific edition of Conjur that you're using:
 
 ```shell
-./bin/transform --oss # Creates a spec definition for Conjur OSS in out/oss/
+./bin/transform --oss # Creates a spec definition for Conjur Open Source in out/oss/
 ./bin/transform --enterprise # Creates a spec definition for Conjur Enterprise in out/enterprise/
 ```
 

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,7 +1,7 @@
 # Spec-Generated Python API Client Example
 
 This example is meant to give an example use case for OpenAPI spec generated clients.
-It covers using some of the most popular Conjur OSS endpoints with Python:
+It covers using some of the most popular Conjur Open Source endpoints with Python:
 - Authenticate a user
 - Change user's own password
 - Rotate user's API key

--- a/examples/ruby/README.md
+++ b/examples/ruby/README.md
@@ -1,7 +1,7 @@
 # Spec-Generated Ruby API Client Example
 
 This example is meant to give an example use case for OpenAPI spec generated clients.  
-It covers using some of the most popular Conjur OSS endpoints with Ruby:
+It covers using some of the most popular Conjur Open Source endpoints with Ruby:
 - Authenticate a user
 - Change user's own password
 - Rotate user's API key

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 info:
-  description: "This is an API definition for CyberArk Conjur OSS. You can find out more at [Conjur.org](https://www.conjur.org/)."
+  description: "This is an API definition for CyberArk Conjur Open Source. You can find out more at [Conjur.org](https://www.conjur.org/)."
   version: 5.1.1
   title: "Conjur"
   contact:

--- a/spec/status.yml
+++ b/spec/status.yml
@@ -279,7 +279,7 @@ components:
           These routes do not require authentication.
 
           The health check attempts an internal HTTP or TCP connection to
-          each DAP service. It also attempts a simple transaction against all internal databases.
+          each Conjur Enterprise service. It also attempts a simple transaction against all internal databases.
         operationId: "health"
         responses:
           "200":
@@ -297,9 +297,9 @@ components:
           enterprise-only: true
         tags:
           - "status"
-        summary: "Health info about a given DAP server"
+        summary: "Health info about a given Conjur Enterprise server"
         description: |
-          Use the remote_health route to check the health of any DAP Server from any other DAP Server.
+          Use the remote_health route to check the health of any Conjur Enterprise Server from any other Conjur Enterprise Server.
           With this route, you can check master health relative to a follower, or follower health relative
           to a standby, and so on.
         operationId: "remoteHealth"
@@ -326,9 +326,9 @@ components:
           enterprise-only: true
         tags:
           - "status"
-        summary: "Basic information about the DAP server"
+        summary: "Basic information about the Conjur Enterprise server"
         description: |
-          Information about the DAP node which was queried against.
+          Information about the Conjur Enterprise node which was queried against.
 
           Includes authenticator info, release/version info, configuration details,
           internal services, and role information.


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
