### PR TITLE
Updated contract test action to run daily at 12am

### DIFF
--- a/.github/workflows/api_contract.yml
+++ b/.github/workflows/api_contract.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, edited]
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight
 
 jobs:
   contract_test:


### PR DESCRIPTION
### What does this PR do?
Updated API contract test so it runs daily at midnight. This is to make sure that we see a failure before someone opens a PR which could take a while.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
