### PR TITLE
Allow deployment of stable Conjur version

### DIFF
--- a/bin/generate_client
+++ b/bin/generate_client
@@ -140,6 +140,6 @@ docker run --rm \
     -g "$client_lang" \
     -o "/out/" \
     $client_config \
-    $template_arg
+    $template_arg 1> /dev/null
 
 echo "Done! Client is in $output_volume folder!"

--- a/bin/generate_postman_collection
+++ b/bin/generate_postman_collection
@@ -56,7 +56,7 @@ cmd="python3 examples/postman/postman_env_setup.py"
 arg=""
 
 if [[ local_env -eq 1 ]]; then
-    ensure_conjur_up
+    ensure_conjur_up latest
 
     export CONJUR_AUTHN_API_KEY="$(docker-compose exec conjur conjurctl role retrieve-key dev:user:admin | tr -d '\r')"
 

--- a/bin/start_conjur
+++ b/bin/start_conjur
@@ -1,6 +1,41 @@
 #!/usr/bin/env bash
 source bin/util
 
+print_help() {
+  cat << EOF
+This script starts Conjur Open Source in a docker-compose environment.
+
+USAGE
+./bin/start_conjur [options]
+
+OPTIONS
+-h|--help       Print help message.
+-s|--stable     Start the latest stable version of Conjur Open Source.
+                By default, the 'edge' version is used, which includes as yet
+                unreleased content.
+EOF
+}
+
+conjur_tag=""
+
+while test $# -gt 0
+do
+  param=$1
+  shift
+  case "$param" in
+    -h|--help)
+      print_help
+      exit 0
+      ;;
+    -s|--stable)
+      conjur_tag="latest"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 cleanup() {
   echo "Cleaning up..."
   docker-compose rm --stop --force -v
@@ -23,6 +58,7 @@ echo "Building services..."
 docker-compose build pg conjur conjur-https
 
 # Start Conjur server
+export CONJUR_OPEN_SOURCE_IMAGE_TAG="${conjur_tag:-$CONJUR_OPEN_SOURCE_IMAGE_TAG}"
 echo "Starting Conjur..."
 docker-compose up -d conjur conjur-https
 docker-compose exec -T conjur conjurctl wait

--- a/bin/test_api_contract
+++ b/bin/test_api_contract
@@ -2,6 +2,7 @@
 source bin/util
 
 endpoint_flag=""
+conjur_tag="latest"
 
 while test $# -gt 0; do
   case "$1" in
@@ -16,6 +17,7 @@ while test $# -gt 0; do
       echo
       echo "-h, --help                show help"
       echo "-e, --endpoint <path>     test endpoints starting with the given path"
+      echo "-s, --stable              test against the latest stable version of Conjur Open Source"
       exit 0
       ;;
     -e|--endpoint)
@@ -27,6 +29,10 @@ while test $# -gt 0; do
       fi
       shift
       ;;
+    -s|--stable)
+      conjur_tag="edge"
+      shift
+      ;;
     *)
       break
       ;;
@@ -35,6 +41,7 @@ done
 
 if [[ -z "$(docker-compose ps -q)" ]]; then
   announce "Environment not found. Spinning up..."
+  export CONJUR_OPEN_SOURCE_IMAGE_TAG="$conjur_tag"
   ./bin/start_conjur 1> /dev/null
   echo
 fi

--- a/bin/test_integration
+++ b/bin/test_integration
@@ -27,6 +27,7 @@ OPTIONS
                             This option does not maintaing Conjur Enterprise.
        	                    WARNING: may cause failing test cases.
 --no-regen-client           Prevent the script from re-generating the client library.
+-s|--stable                 Runs tests against the latest stable version of Conjur Open Source.
 -t|--test <test>            Runs a given test in a client test suite.
 EOF
 }
@@ -42,6 +43,7 @@ enterprise=0
 appliance="oss"
 enterprise_params=""
 docker_network="openapi-spec"
+conjur_open_source_tag="edge"
 
 no_regen_client=0
 no_rebuid_conjur=0
@@ -86,6 +88,9 @@ do
       ;;
     --no-regen-client)
       no_regen_client=1
+      ;;
+    -s|--stable)
+      conjur_open_source_tag="latest"
       ;;
     -t|--test)
       test="$1"
@@ -197,11 +202,12 @@ if [[ $no_rebuild_conjur -eq 0 ||
 ( $(conjur_alive) -eq 1 && $enterprise -eq 0 ) ||
 ( $(enterprise_alive) -eq 1 && $enterprise -eq 1 ) ]]; then
   if [[ $enterprise -eq 0 ]]; then
-	announce "Starting Conjur OSS"
-	bin/start_conjur
+    announce "Starting Conjur OSS"
+    export CONJUR_OPEN_SOURCE_IMAGE_TAG="$conjur_open_source_tag"
+    bin/start_conjur
   else
     announce "Starting Conjur Enterprise"
-	  bin/start_enterprise
+    bin/start_enterprise
 
     pushd  ./test/dap-intro
     # Create the parameter to import volumes from the Enterprise container so we have its certificates

--- a/bin/util
+++ b/bin/util
@@ -41,11 +41,21 @@ function ensure_client_is_generated(){
 }
 
 function ensure_conjur_up(){
+  desired_tag="$1"
+  export CONJUR_OPEN_SOURCE_IMAGE_TAG="$desired_tag"
   if [ -z $(docker-compose ps -q conjur) ]; then
     announce "Starting Conjur container"
     ./bin/start_conjur
   else
-    announce "Conjur already up!"
+    docker ps | grep openapi | grep cyberark/conjur | grep $desired_tag > /dev/null
+    desired_tag_deployed="$?"
+    if [[ "$desired_tag_deployed" == "0" ]]; then
+      announce "Conjur already up!"
+    else
+      announce "Conjur not deployed with tag $desired_tag. Re-deploying..."
+      ./bin/stop
+      ./bin/start_conjur
+    fi
   fi
 }
 

--- a/bin/util
+++ b/bin/util
@@ -14,9 +14,9 @@ function get_banner(){
 
 function announce() {
   banner=$(get_banner $@)
-  echo -e "\e[0;32m$banner"
+  echo -e "\033[0;32m$banner"
   echo -e "$@"
-  echo -e "$banner\e[m"
+  echo -e "$banner\033[m"
 }
 
 function ensure_client_is_generated(){

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,5 +148,4 @@ services:
 
 networks:
   default:
-    external:
-      name: openapi-spec
+    name: openapi-spec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   conjur:
-    image: cyberark/conjur:edge
+    image: cyberark/conjur:${CONJUR_OPEN_SOURCE_IMAGE_TAG:-edge}
     command: server -a dev -f /policy/policy.yaml
     environment:
       CONJUR_DATA_KEY: 'OyXV68Mip14xj33huGaQKewmmS+gKtDlp6ECZ2iATpU='

--- a/examples/kong/start
+++ b/examples/kong/start
@@ -39,27 +39,30 @@ announce "Ensure Kong Gateway is active"
 if [[ -z $(curl -s http://localhost:8001/services/Conjur | grep '"name":"Conjur"') ]]; then
     echo "Kong setup failed"
     exit 1
-else
-    echo "Kong setup successful"
 fi
 
 announce "Making requests to Conjur through Kong Gateway"
 
-ensure_conjur_up
+set +e
+ensure_conjur_up latest
 sleep 10
+set -e
 
 admin_api_key="$(docker-compose exec -T conjur conjurctl role retrieve-key dev:user:admin | tr -d '\r')"
 token="$(curl -s http://localhost:8000/authn/dev/admin/authenticate \
     --header "Accept-Encoding: base64" \
     --data $admin_api_key)"
 
-secret_data="Hello World!"
+curl -X POST http://localhost:8000/policies/dev/policy/root \
+    -H "Authorization: Token token=\"$token\"" \
+    --data "$(< examples/config/policy.yml)" 1> /dev/null
 
-curl -is http://localhost:8000/secrets/dev/variable/testSecret \
+secret_data="Hello World!"
+curl -is http://localhost:8000/secrets/dev/variable/sampleSecret \
     -H "Authorization: Token token=\"$token\"" \
     --data "$secret_data"
 
-retrieved_secret="$(curl http://localhost:8000/secrets/dev/variable/testSecret \
+retrieved_secret="$(curl http://localhost:8000/secrets/dev/variable/sampleSecret \
     -H "Authorization: Token token=\"$token\"")"
 
 if [ "$secret_data" == "$retrieved_secret" ]; then

--- a/examples/python/start
+++ b/examples/python/start
@@ -1,10 +1,8 @@
 #!/bin/bash
-set -e
-
 source ./bin/util
 
-ensure_client_is_generated python conjur
-ensure_conjur_up
+ensure_client_is_generated python oss
+ensure_conjur_up latest
 
 export CONJUR_ADMIN_API_KEY=$(get_conjur_admin_api_key)
 

--- a/examples/ruby/start
+++ b/examples/ruby/start
@@ -1,10 +1,8 @@
 #!/bin/bash
-set -e
-
 source ./bin/util
 
-ensure_client_is_generated ruby conjur
-ensure_conjur_up
+ensure_client_is_generated ruby oss
+ensure_conjur_up latest
 
 # Remove the gem if it is already built so we dont create a gemfile
 # which contains itself when we build


### PR DESCRIPTION
### Desired Outcome

Scripts for testing and examples should be able to run against the latest stable version of Conjur.
Scripts run against `cyberark/conjur:edge` for its advantages:
- bug discovery of unreleased changes in the Conjur server
- ensure that the OpenAPI description is kept in-phase with the server

Users that aren't actively developing the project should be able to run these tests/examples without
being made aware of possible bugs.

### Implemented Changes

- `bin/start_conjur` can be configured in two ways:
  - `--stable` flag (prioritized)
  - global environment variable `CONJUR_OPEN_SOURCE_IMAGE_TAG`
- Scripts that call `bin/start_conjur` use either of the above methods
- `util` function `ensure_conjur_up` also ensures that a deployed version of Conjur is of the desired tag
- Examples always run against that latest stable version
- `bin/test_integration` and `bin/test_api_contract` scripts can be called with the `--stable` flag, but default to using Conjur's `edge` version
- CI pipelines run against `cyberark/conjur:edge` to maintain the advantages listed above.

### Connected Issue/Story

Resolves #213 

CyberArk internal issue link: N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
