### PR TITLE
Updated how keycloak container certs are retrieved

### DIFF
--- a/test/config/oidc/fetchCertificate
+++ b/test/config/oidc/fetchCertificate
@@ -1,13 +1,18 @@
 #!/bin/sh
 
-# This script retrieves a certificate from the keycloak OIDC provider.
+# This script retrieves a certificate from the keycloak OIDC provider
+# and puts it to a trusted operating system store.
 # It is needed to communicate with the provider via SSL for validating ID tokens
 
-httpclient_pem_location="/var/lib/ruby/lib/ruby/gems/2.5.0/gems/httpclient-2.8.3/lib/httpclient"
+openssl s_client \
+  -showcerts \
+  -connect keycloak:8443 \
+  -servername keycloak \
+  </dev/null | \
+  openssl x509 \
+    -outform PEM \
+    >/etc/ssl/certs/keycloak.pem
 
-echo "keycloak cert" >> "$httpclient_pem_location/cacert.pem"
-echo =============== >> "$httpclient_pem_location/cacert.pem"
-echo | openssl s_client -showcerts -connect keycloak:8443 -servername keycloak 2>/dev/null | openssl x509 -outform PEM >>  "$httpclient_pem_location/cacert.pem"
-echo "keycloak cert" >> "$httpclient_pem_location/cacert1024.pem"
-echo =============== >> "$httpclient_pem_location/cacert1024.pem"
-echo | openssl s_client -showcerts -connect keycloak:8443 -servername keycloak 2>/dev/null | openssl x509 -outform PEM >>  "$httpclient_pem_location/cacert1024.pem"
+hash=$(openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
+
+ln -s /etc/ssl/certs/keycloak.pem "/etc/ssl/certs/${hash}.0"


### PR DESCRIPTION
### Implemented Changes

The keycloak certs are now properly fetched based on updates to Conjur OIDC.

### Connected Issue/Story
[related](https://github.com/cyberark/conjur-sdk-java/pull/66)

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
