### PR TITLE
Updates openapi.yml with license name and URL information

### DIFF
--- a/bin/generate_kong_config
+++ b/bin/generate_kong_config
@@ -22,7 +22,7 @@ echo "servers:
 announce "Generating Kong declarative configuration yaml"
 docker run --rm \
     -v ${PWD}:/opt/openapi \
-    node:15 /bin/bash -c "
+    node:18 /bin/bash -c "
         npm i -g insomnia-inso \
         && cd /opt/openapi \
         && inso --verbose \

--- a/bin/generate_postman_collection
+++ b/bin/generate_postman_collection
@@ -76,7 +76,7 @@ docker run --rm \
     -w /openapi \
     --env CONJUR_AUTHN_API_KEY \
     --env CONJUR_ADMIN_TOKEN \
-    python:3.9 \
+    python:3 \
     /bin/bash -c "
         $cmd $arg
     "

--- a/bin/lint_tests
+++ b/bin/lint_tests
@@ -9,7 +9,7 @@ docker run --rm \
     -v ${PWD}/test/config/.pylintrc:/code/.pylintrc \
     -v ${PWD}/out/enterprise/python:/code/module \
     -v ${PWD}/requirements.txt:/requirements.txt \
-    python:3.8 \
+    python:3 \
     /bin/bash -c "pip install -r /requirements.txt && pip install pylint -e /code/module && pylint --rcfile=/code/.pylintrc /code/test"
 
 if [ $? -ne 0 ]

--- a/bin/start_conjur
+++ b/bin/start_conjur
@@ -15,6 +15,10 @@ if [ $(enterprise_alive) -eq 0 ]; then
   stop_enterprise
 fi
 
+if [ $(conjur_alive) -eq 0 ]; then
+  stop_oss
+fi
+
 trap 'echo "ERROR: Test script encountered an error!"; docker-compose logs; cleanup' ERR
 
 docker network create openapi-spec

--- a/bin/start_enterprise
+++ b/bin/start_enterprise
@@ -5,6 +5,10 @@ if [ $(conjur_alive) -eq 0 ]; then
   stop_oss
 fi
 
+if [ $(enterprise_alive) -eq 0 ]; then
+  stop_enterprise
+fi
+
 rm -rf test/dap-intro
 git clone https://github.com/conjurdemos/dap-intro.git test/dap-intro
 chmod -R 777 test/dap-intro

--- a/bin/test_integration
+++ b/bin/test_integration
@@ -189,7 +189,7 @@ run_python_tests(){
     docker run --rm $enterprise_params \
       --network $docker_network \
       --env-file .env \
-      python-tests bash -c "nose2 -v -s test ${test_params}"
+      python-tests bash -c "nose2 -v -s test ${test_params} --with-coverage --coverage-report xml"
   fi
 }
 

--- a/bin/transform
+++ b/bin/transform
@@ -14,7 +14,7 @@ docker run --rm \
     -v ${PWD}:/code \
     -w /code \
     --env VERSION \
-    python:3.9 \
+    python:3 \
     /bin/bash -c "
         pip install pyyaml
 

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -7,6 +7,8 @@ info:
   contact:
     email: "conj_maintainers@cyberark.com"
   license:
+    # These values are overwritten by the client as the generator did not correctly read the license name.
+    # See https://github.com/cyberark/conjur-sdk-java/blob/main/config/java.yml
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
 

--- a/test/Dockerfile.api
+++ b/test/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 WORKDIR /cyberark
 

--- a/test/Dockerfile.python
+++ b/test/Dockerfile.python
@@ -1,9 +1,10 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV INSTALL_DIR=/opt/conjur-openapi-spec
 
-RUN apt-get update && \
-    apt-get install -y bash \
+RUN apt-get -y update && \
+    apt-get install -y apt-transport-https \
+                       bash \
                        binutils \
                        build-essential \
                        git \


### PR DESCRIPTION
### Desired Outcome

- Clarifies that the client overwrites the license name due to the generator not reading in the correct license name, "Apache 2.0"

### Implemented Changes

Added comment that points to the Java config changes.

### Connected Issue/Story
ONYX-16679