### PR TITLE
Use ca-cert variable for keycloak tests

### DIFF
--- a/bin/test_integration
+++ b/bin/test_integration
@@ -118,6 +118,7 @@ setup_keycloak(){
   docker-compose exec -T oidc-keycloak bash -c "/scripts/create_client"
   docker-compose exec -T oidc-keycloak bash -c "/scripts/create_user bob bob bob@conjur.net"
   docker-compose exec -T conjur bash -c "/policy/oidc/fetchCertificate"
+  export KEYCLOAK_CERT="$(docker compose exec conjur cat /etc/ssl/certs/keycloak.pem)"
 }
 
 gen_client() {
@@ -181,6 +182,7 @@ run_python_tests(){
     docker-compose run \
       --rm \
       --no-deps \
+      --env KEYCLOAK_CERT \
       test-python \
       nose2 --plugin nose2.plugins.junitxml --with-coverage --coverage-report xml -X -v -s test ${test_params}
   else
@@ -188,6 +190,7 @@ run_python_tests(){
 
     docker run --rm $enterprise_params \
       --network $docker_network \
+      --env KEYCLOAK_CERT \
       --env-file .env \
       python-tests bash -c "nose2 -v -s test ${test_params}"
   fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,5 +148,5 @@ services:
 
 networks:
   default:
-    external:
-      name: openapi-spec
+    name: openapi-spec
+    external: true

--- a/test/config/oidc-webservice.yml
+++ b/test/config/oidc-webservice.yml
@@ -11,6 +11,7 @@
 
   - !variable provider-uri
   - !variable id-token-user-property
+  - !variable ca-cert
 
   - !permit
     role: !group users

--- a/test/config/oidc/fetchCertificate
+++ b/test/config/oidc/fetchCertificate
@@ -12,7 +12,3 @@ openssl s_client \
   openssl x509 \
     -outform PEM \
     >/etc/ssl/certs/keycloak.pem
-
-hash=$(openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null)
-
-ln -s /etc/ssl/certs/keycloak.pem "/etc/ssl/certs/${hash}.0"

--- a/test/python/api_config.py
+++ b/test/python/api_config.py
@@ -10,6 +10,7 @@ CERT_DIR = pathlib.Path(os.environ.get('CERT_DIR', default='config/https'))
 SSL_CERT_FILE = os.environ.get('SSL_CERT_FILE', default='ca.crt')
 CONJUR_CERT_FILE = os.environ.get('CONJUR_CERT_FILE', default='conjur.crt')
 CONJUR_KEY_FILE = os.environ.get('CONJUR_KEY_FILE', default='conjur.key')
+KEYCLOAK_CERT = os.environ.get('KEYCLOAK_CERT')
 
 # Environment Constants
 CONJUR_AUTHN_API_KEY = 'CONJUR_AUTHN_API_KEY'
@@ -110,6 +111,12 @@ def setup_oidc_webservice():
         'variable',
         'conjur/authn-oidc/test/id-token-user-property',
         body='preferred_username'
+    )
+    secrets_api.create_secret(
+        account,
+        'variable',
+        'conjur/authn-oidc/test/ca-cert',
+        body=KEYCLOAK_CERT
     )
 
 class ConfiguredTest(unittest.TestCase):


### PR DESCRIPTION
### Desired Outcome

Fix pipeline failures due to OpenSSL changes. 

### Implemented Changes

Use updated authn-oidc configurability to provide the CA cert via Conjur policy

NOTE: this update is not required for this flow to work. The new `ca-cert` variable does not break the previous strategy. The reason these tests failed was a faulty openssl command:
```diff
- openssl x509 -hash -in /etc/ssl/certs/keycloak.pem -out /dev/null
+ openssl x509 -hash -in /etc/ssl/certs/keycloak.pem --noout
```

Additional changes:
- Fix docker compose external network deprecation warnings

NOTE: Kong examples are still failing due to changes with the Inso CLI that will be resolved in a separate effort.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
